### PR TITLE
fix: put stadnard code owners parts back

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,12 @@
 * @midnightntwrk/mn-techwriting @midnightntwrk/mn-devrel 
 
 /docs/develop/reference/compact/lang-ref.mdx @midnightntwrk/mn-codeowners-compact
+/.github/ISSUE_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
+/.github/PULL_REQUEST_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
+/.github/workflows/checkmarx.yaml @midnightntwrk/mn-security @midnightntwrk/mn-sre
+/.github/workflows/dependabot.yml @midnightntwrk/mn-security @midnightntwrk/mn-sre
+CODE_OF_CONDUCT.md @midnightntwrk/mn-security @midnightntwrk/mn-sre
+CODEOWNERS @midnightntwrk/mn-security @midnightntwrk/mn-sre
+CONTRIBUTING.md @midnightntwrk/mn-security @midnightntwrk/mn-sre
+LICENSE @midnightntwrk/mn-security @midnightntwrk/mn-sre
+SECURITY.md @midnightntwrk/mn-security @midnightntwrk/mn-sre


### PR DESCRIPTION
This brings it into line with midnight-template-repo.