### PR TITLE
fix: use maintained action rather than fork

### DIFF
--- a/.github/workflows/apis.yml
+++ b/.github/workflows/apis.yml
@@ -211,7 +211,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - uses: MonikaJassova/ghcommit-action@aee0efc02d3707e178c534477e5c87f70fe6678f
+      - name: Add any untracked changes
+        if: ${{ steps.prep.outputs.UPDATE == 'true' }}
+        run: git add --all
+
+      - uses: planetscale/ghcommit-action@07f47f9da58677783fcc5ecc6bbfce16cc015685  # v0.2.17
         if: ${{ steps.prep.outputs.UPDATE == 'true' }}
         with:
           commit_message: "Copy API docs from other repositories"


### PR DESCRIPTION
Her fork was adding untracked files: https://github.com/planetscale/ghcommit-action/compare/main...MonikaJassova:ghcommit-action:main

We can do this as a separate step and go back to using the unforked action.