### PR TITLE
fix: use maintained fork

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # 5.0.0
 
       - name: Check links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@75e8eff79b17a74255f5d39b8e8fe66b9ce891f6
         with:
           use-quiet-mode: 'no'
           use-verbose-mode: 'yes'


### PR DESCRIPTION
The original action has been deprecated as the author has made an alternative link checker. The new one doesn't seem to allow .mdx files to be configured so have switched to the maintained fork of the original action.