### PR TITLE
refactor: seperate compact docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -200,6 +200,14 @@ const config = {
       },
       items: [
         {
+          type: "docSidebar",
+          sidebarId: "compact",
+          docId: "develop/reference/compact/index",
+          label: "Compact",
+          position: "left",
+          className: "hide-on-mobile"
+        },
+        {
           to: "/blog",
           label: "Dev Diaries",
           position: "left",
@@ -214,6 +222,15 @@ const config = {
           activeBasePath: "/academy",
           activeBaseRegex: "^/academy/?",
           className: "hide-on-mobile"
+        },
+        
+        {
+          type: "docSidebar",
+          sidebarId: "compact",
+          docId: "develop/reference/compact/index",
+          label: "Compact language",
+          position: "left",
+          className: "hide-on-desktop"
         },
         {
           to: "/blog",

--- a/sidebars.js
+++ b/sidebars.js
@@ -222,51 +222,17 @@ module.exports = {
       ]
     },
 
-    // COMPACT LANGUAGE - All existing content
+    // COMPACT LANGUAGE
     {
       type: "category",
       label: "Compact language",
       collapsed: true,
       items: [
         {
-          type: "category",
-          label: "Language reference",
-          link: { type: "doc", id: "develop/reference/compact/index" },
-          items: [
-            "develop/reference/compact/writing",
-            "develop/reference/compact/lang-ref",
-            "develop/reference/compact/compact-grammar",
-            "develop/reference/compact/ledger-adt",
-            "develop/reference/compact/opaque_data",
-            "develop/reference/compact/explicit_disclosure",
-            {
-              type: "category",
-              label: "Compact standard library",
-              link: {
-                type: "doc",
-                id: "develop/reference/compact/compact-std-library/README"
-              },
-              items: ["develop/reference/compact/compact-std-library/exports"]
-            }
-          ]
-        },
-        {
-          type: "category",
-          label: "Tools",
-          link: { type: "doc", id: "develop/reference/tools/index" },
-          items: [
-            "develop/reference/tools/compiler-usage",
-            {
-              type: "category",
-              label: "VS Code plugin",
-              link: {
-                type: "doc",
-                id: "develop/reference/tools/vsc-plugin/index"
-              },
-              items: []
-            }
-          ]
-        }
+          type: "doc",
+          id: "develop/reference/compact/index",
+          label: "Open Compact language docs"
+        } 
       ]
     },
 
@@ -1068,7 +1034,7 @@ module.exports = {
           ]
         }
       ]
-    },
+    }, 
 
     // TROUBLESHOOTING
     {
@@ -1194,7 +1160,7 @@ module.exports = {
           label: "Compatibility matrix"
         }
       ]
-    },
+    }, 
 
     // GLOSSARY
     {
@@ -1208,6 +1174,56 @@ module.exports = {
       type: "link",
       label: "Dev diaries",
       href: "/blog"
+    }
+  ],
+
+  // Standalone sidebar showing only Compact language content
+  compact: [
+    {
+      type: "category",
+      label: "Compact language",
+      collapsed: false,
+      items: [
+        {
+          type: "category",
+          label: "Language reference",
+          link: { type: "doc", id: "develop/reference/compact/index" },
+          items: [
+            "develop/reference/compact/writing",
+            "develop/reference/compact/lang-ref",
+            "develop/reference/compact/compact-grammar",
+            "develop/reference/compact/ledger-adt",
+            "develop/reference/compact/opaque_data",
+            "develop/reference/compact/explicit_disclosure",
+            {
+              type: "category",
+              label: "Compact standard library",
+              link: {
+                type: "doc",
+                id: "develop/reference/compact/compact-std-library/README"
+              },
+              items: ["develop/reference/compact/compact-std-library/exports"]
+            }
+          ]
+        },
+        {
+          type: "category",
+          label: "Tools",
+          link: { type: "doc", id: "develop/reference/tools/index" },
+          items: [
+            "develop/reference/tools/compiler-usage",
+            {
+              type: "category",
+              label: "VS Code plugin",
+              link: {
+                type: "doc",
+                id: "develop/reference/tools/vsc-plugin/index"
+              },
+              items: []
+            }
+          ]
+        }
+      ]
     }
   ]
 };

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -115,7 +115,8 @@ nav.theme-doc-sidebar-menu {
 }
 
 /* Top-level categories - UPPERCASE */
-.theme-doc-sidebar-item-category > .menu__list-item-collapsible > .menu__link {
+.theme-doc-sidebar-item-category > .menu__list-item-collapsible > .menu__link,
+.theme-doc-sidebar-item-category > .menu__link {
   color: var(--ifm-heading-color) !important;
   font-size: 0.875rem !important;  /* Increased from 0.75rem */
   font-weight: 700 !important;
@@ -134,7 +135,8 @@ nav.theme-doc-sidebar-menu {
   letter-spacing: normal !important;
 }
 
-.theme-doc-sidebar-item-category > .menu__list-item-collapsible > .menu__link:hover {
+.theme-doc-sidebar-item-category > .menu__list-item-collapsible > .menu__link:hover,
+.theme-doc-sidebar-item-category > .menu__link:hover {
   opacity: 1 !important;
   background: transparent !important;
   text-decoration: none !important;
@@ -256,7 +258,8 @@ nav.theme-doc-sidebar-menu {
 
 /* External link icon for blog/external links */
 .menu__link[href^="http"]::after,
-.menu__link[href*="/blog"]::after {
+.menu__link[href*="/blog"]::after,
+.menu__link[href*="/develop/reference/compact"]::after {
   content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'%3E%3C/path%3E%3Cpolyline points='15 3 21 3 21 9'%3E%3C/polyline%3E%3Cline x1='10' y1='14' x2='21' y2='3'%3E%3C/line%3E%3C/svg%3E") !important;
   margin-left: 4px !important;
   display: inline-block !important;


### PR DESCRIPTION
### Description

This PR changes are to separate the Compact docs to be in a separate view to make it more clearer for the developers and less distracting.

### Screenshots
#### Docs home
<img width="2156" height="1311" alt="Screenshot_20251028_113823" src="https://github.com/user-attachments/assets/d06a4e7f-2b54-4ab4-8ede-cc79c4602542" />

#### Compact page
<img width="2150" height="1081" alt="Screenshot_20251028_113913" src="https://github.com/user-attachments/assets/d100c7c9-884a-404b-a2e1-0e8294429be3" />

