### PR TITLE
feat(docs): how-to tutorial for a wallet connector with DApp API

### DIFF
--- a/docs/develop/how-to/react-wallet-connect.mdx
+++ b/docs/develop/how-to/react-wallet-connect.mdx
@@ -1,0 +1,244 @@
+---
+title: Create a React Wallet Connector
+description: Learn how to create a React application that connects to a wallet using the Midnight DApp Connector API.
+sidebar_position: 3
+sidebar_label: Create a React Wallet Connector
+tags: [wallet, react, tutorial]
+slug: /how-to/react-wallet-connect
+toc_max_heading_level: 2
+---
+
+import Step, { StepsProvider } from "@site/src/components/Step/Step";
+
+# Building a React Wallet Connector with Midnight DApp API
+
+This tutorial will guide you through creating a React application that connects to a wallet using the Midnight DApp Connector API.
+
+The code examples in this tutorial intentionally omit CSS and visual styling to keep the examples focused and easy to read. The actual [example app code](https://github.com/bochaco/react-mn-wallet-connect) includes full styling (Tailwind classes and additional CSS) so the components are displayed with a polished, user-friendly appearance.
+
+Also, the code in this tutorial is framework-agnostic and can be used with any React framework. You can drop these components and logic into projects created with Vite, Create React App, Next.js, Remix, Gatsby, or custom setups — you may only need to adjust the entry file (e.g. src/main.tsx vs src/index.tsx), routing, or build configuration to match your chosen scaffold.
+
+## Prerequisites
+The following is required:
+
+- Familiarity with TypeScript/JavaScript
+- Basic understanding of React
+- [Midnight Lace wallet extension](https://chromewebstore.google.com/detail/lace-beta/hgeekaiplokcnmakghbdfbgnlfheichg) installed in your browser.
+
+After using this tutorial, you should:
+
+- Understand basic Midnight wallet connection flow
+- Know how to use @midnight-ntwrk/dapp-connector-api
+- Have working starter code to build your own applications
+
+<StepsProvider>
+<Step>
+
+**Define TypeScript Interfaces**
+
+Let's first define a interface for the props passed between the component we are going to create. Their main purpose is to provide type safety and clear contracts for components. WalletCard describes the connection state and callbacks used by the app to trigger connect/disconnect actions.
+
+The actual implementation of the interfaces shown below can be found in the example app at [src/types.ts](https://github.com/bochaco/react-mn-wallet-connect/blob/main/src/types.ts).
+
+```typescript
+export interface WalletCardProps {
+  isConnected: boolean;
+  walletAddress: string | null;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}
+```
+
+</Step>
+<Step>
+
+**Create WalletCard Component**
+
+The `WalletCard` aggregates UI and actions related to the wallet connection: it shows status, displays the address when available, and exposes connect/disconnect actions via the Button component. 
+
+Its main role in the app is to be the single visible component that reflects the wallet connection state and triggers the logic handled by the `App` component we'll define afterwards.
+
+The `WalletCard` component as implemented in the example app can be found at [src/WalletCard.tsx](https://github.com/bochaco/react-mn-wallet-connect/blob/main/src/WalletCard.tsx).
+
+```typescript
+import React from "react";
+import type { WalletCardProps } from "./types";
+
+const WalletCard: React.FC<WalletCardProps> = ({
+  isConnected,
+  walletAddress,
+  onConnect,
+  onDisconnect,
+}) => {
+  return (
+    <div>
+      <div>
+        <h2>Connection Status</h2>
+        <div className={isConnected ? "text-green-400" : "text-red-400"}>
+          {isConnected ? "Connected" : "Disconnected"}
+        </div>
+      </div>
+
+      <div>
+        {isConnected && walletAddress ? (
+          <>
+            <p>Wallet Address:</p>
+            <p title={walletAddress}>{walletAddress}</p>
+          </>
+        ) : (
+          <p>Please connect your wallet to proceed.</p>
+        )}
+      </div>
+
+      <div>
+        {isConnected ? (
+          <button onClick={onDisconnect}>Disconnect Wallet</button>
+        ) : (
+          <button onClick={onConnect}>Connect Wallet</button>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+</Step>
+<Step>
+
+**Create Main App Component**
+
+We need one last component, the `App` component, which manages state and business logic: it holds connection state and the current wallet address, and provides callbacks to child components to change that state. 
+
+To begin with, the connect handler is a stub producing a dummy wallet address; later on we will call the Midnight DApp Connector. `App` wires UI (WalletCard) to the connector logic and is the central coordinator for the application.
+
+The `App` component shown below is implemented in the example app at [src/App.tsx](https://github.com/bochaco/react-mn-wallet-connect/blob/main/src/App.tsx).
+
+```typescript
+import React, { useState } from 'react';
+import WalletCard from './WalletCard';
+
+const App: React.FC = () => {
+  const [isConnected, setIsConnected] = useState<boolean>(false);
+  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+
+  const handleConnect = () => {
+    // We will replace this to actually use the Midnight DApp connector API.
+    const fakeAddress = `0x${Array(40).fill(0).join("")}`;
+    setWalletAddress(fakeAddress);
+    setIsConnected(true);
+  };
+
+  const handleDisconnect = () => {
+    setWalletAddress(null);
+    setIsConnected(false);
+  };
+
+  return (
+    <div>
+      <header>
+        <h1>Midnight Wallet Connector</h1>
+      </header>
+      <main>
+        <WalletCard
+          isConnected={isConnected}
+          walletAddress={walletAddress}
+          onConnect={handleConnect}
+          onDisconnect={handleDisconnect}
+        />
+      </main>
+    </div>
+  );
+};
+```
+
+</Step>
+<Step>
+
+**Create Entry Point**
+
+At this point we are ready to bootstrap the React application into the DOM. We can now mount the `App` component and ensure React runs in StrictMode during development.
+
+In the implemented example it also pulls in Tailwind-generated CSS so the UI renders with the intended styling, this can be found at [src/main.tsx](https://github.com/bochaco/react-mn-wallet-connect/blob/main/src/main.tsx).
+
+```typescript
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);
+```
+
+Lastly, we create the HTML file providing the hosting page for the single-page app and links the global stylesheet. The HTML used by the example app is available at [index.html](https://github.com/bochaco/react-mn-wallet-connect/blob/main/index.html).
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <link rel="stylesheet" href="/index.css">
+    <title>React Midnight Wallet Connector</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+```
+
+Your application should now be displaying a dummy address, so now we are ready to add the last piece to integrate it with the Midnight DApp Connector, to retrieve the actual wallet's address.
+
+</Step>
+<Step>
+
+**Integrate Midnight DApp Connector**
+
+Let's now replace `handleConnect` function body in the `App` component with a real implementation using the DApp Connector API.
+
+This code demonstrates how to call the Midnight DApp Connector API to enable the wallet, check whether it's enabled, and retrieve the current wallet state (including the address). With this code, the `WalletCard` displays the real address and connection status:
+
+The DApp connector API should be exposed through the global variable `window.midnight.{walletName}`.
+
+```typescript
+const handleConnect = async () => {
+  let isConnected = false;
+  let address = null;
+  try {
+    // To authorize a DApp, call the enable() method and wait for 
+    // the user to respond to the request.
+    const connectorAPI = await window.midnight?.mnLace.enable();
+
+    // Let's now check if the DApp is authorized, using the isEnabled() method
+    const isEnabled = await window.midnight?.mnLace.isEnabled();
+    if (isEnabled) {
+      isConnected = true;
+      console.log("Connected to the wallet:", connectorAPI);
+
+      // To get the wallet state, we call the state() API method, that will
+      // return the DAppConnectorWalletState object, which is where we can get 
+      // the wallet address from.
+      const state = await connectorAPI.state();
+      address = state.address;
+    }
+  } catch (error) {
+    console.log("An error occurred:", error);
+  }
+
+  setIsConnected(isConnected);
+  setWalletAddress(address);
+};
+```
+
+</Step>
+</StepsProvider>
+
+Your application should now be running with the Midnight DApp Connector integration, requesting the user to authorise it from the Lace wallet, and displaying the corresponding connection status and wallet address!.
+
+## Next steps
+
+You can consider implementing the following:
+
+- Allowing the user to transfer coins
+- Expose a text input for signing messages with the connected wallet

--- a/sidebars.js
+++ b/sidebars.js
@@ -97,6 +97,11 @@ module.exports = {
         },
         {
           type: "doc",
+          id: "develop/how-to/react-wallet-connect",
+          label: "Create a React Wallet Connector"
+        },
+        {
+          type: "doc",
           id: "develop/how-to/verify-private-data",
           label: "Verify private data"
         },


### PR DESCRIPTION
Adding a how-to tutorial which guides developers through creating a React application that connects to a wallet using the Midnight DApp Connector API.

I've included links to the actual example application code which implements this guide into a working dApp, but let me know if you think they are not required/needed and I will remove them.