### PR TITLE
docs: add create-mn-app quick start section to getting started guide

### DIFF
--- a/docs/getting-started/create-mn-app.mdx
+++ b/docs/getting-started/create-mn-app.mdx
@@ -18,7 +18,7 @@ A Midnight Network (MN) app is a privacy-preserving DApp that uses zero-knowledg
 
 ## Quick start with create-mn-app
 
-The [`create-mn-app`](https://www.npmjs.com/package/create-mn-app) CLI tool scaffolds Midnight Network applications with zero configuration. The tool provides pre-configured TypeScript setup, hot reloading, wallet generation, and automatic dependency management for Node.js, Docker, and the Compact compiler.
+The [`create-mn-app`](https://www.npmjs.com/package/create-mn-app) CLI tool scaffolds Midnight Network applications with zero configuration. The tool provides a preconfigured TypeScript setup, hot reloading, and wallet generation, with automatic dependency management for Node.js, Docker, and the Compact compiler. To install, run the following commands:
 
 ```bash
 npx create-mn-app my-app
@@ -28,18 +28,18 @@ npm run setup
 
 Available templates include Hello World (message storage) and Counter DApp (increment/decrement with zkProofs). Additional templates for Bulletin Board, DEX, and Midnight Kitties are in development.
 
-For manual setup, follow the step-by-step guide below.
+For manual setup, follow these steps:
 
 ## Prerequisites
 
 The following software and tools are required:
 
-* **Node.js**: Version 20.x or higher. Install Node.js using [NVM](https://github.com/nvm-sh/nvm).
+- **Node.js**: Version 20.x or higher. Install Node.js using [NVM](https://github.com/nvm-sh/nvm).
   ```bash
   nvm install 20
   ```
-* **Command-line knowledge**: Basic familiarity with terminal operations.
-* **Code editor**: An IDE such as [Visual Studio Code](https://code.visualstudio.com).
+- **Command-line knowledge**: Basic familiarity with terminal operations.
+- **Code editor**: An IDE such as [Visual Studio Code](https://code.visualstudio.com).
 
 ## Create a project
 


### PR DESCRIPTION
## Description

This PR introduces the `create-mn-app` package to the getting started documentation. The package has been moved to the Midnight Network organization repo and provides an official, zero-configuration CLI tool for scaffolding Midnight applications.

## Changes

- Added "Quick start with create-mn-app" section to the Create an MN app guide
- Provides users with a fast alternative to manual setup while maintaining the step-by-step tutorial for learning purposes
- Includes information about available templates (Hello World, Counter DApp) and automatic dependency management

Now that `create-mn-app` is part of the official Midnight Network organization repo and open source, i think it should be prominently featured in our getting started documentation to help developers scaffold projects quickly and with best practices built-in.