### PR TITLE
fix: address code review feedback on pragma directive and contract ex…

### DIFF
--- a/docs/getting-started/create-mn-app.mdx
+++ b/docs/getting-started/create-mn-app.mdx
@@ -93,10 +93,10 @@ Until Compact 1.0, minor version updates may include breaking changes. Specifyin
 <StepsProvider start={4}>
 <Step>
 
-**Add the pragma directive.** Add the following line to the top of `contracts/hello-world.compact`. This directive specifies language version `0.18`.
+**Add the pragma directive.** Add the following line to the top of `contracts/hello-world.compact`. This directive specifies language version `0.17`.
 
 ```compact
-pragma language_version 0.18;
+pragma language_version 0.17;
 ```
 
 </Step>
@@ -121,7 +121,7 @@ This contract uses the `Opaque<"string">` type, which stores variable-length str
 **Create the ledger declaration.** This line reserves on-chain storage for a string variable named `message`.
 
 ```compact
-pragma language_version 0.18;
+pragma language_version 0.17;
 
 export ledger message: Opaque<"string">;
 ```
@@ -161,7 +161,7 @@ Compact enforces privacy by default. All user input is considered private unless
 The complete `hello-world.compact` contract appears as follows:
 
 ```compact
-pragma language_version 0.18;
+pragma language_version 0.17;
 
 export ledger message: Opaque<"string">;
 


### PR DESCRIPTION
…amples

- Change from open-ended version (>= 0.16) to exact version (0.17)
- Clarify that pragma is optional but recommended best practice
- Remove unnecessary standard library import (contract doesn't need it)
- Use 2-space indentation (official Compact style)
- Change <function> to <name> in syntax examples to avoid TypeScript keyword confusion
- Use consistent angle bracket syntax in circuit syntax examples
- Clarify that disclose is an operator, not a function