### PR TITLE
docs: fix broken link in the kachina documentation

### DIFF
--- a/docs/learn/understanding-midnights-technology/kachina.mdx
+++ b/docs/learn/understanding-midnights-technology/kachina.mdx
@@ -7,7 +7,7 @@ copyright: This file is part of midnight-docs. Copyright (C) 2025 Midnight Found
 
 Kachina is a data-protecting smart contract solution that enables its users to achieve confidential and general-purpose smart contract functionality without sacrificing decentralization characteristics. Kachina offers a practical protocol for realizing data-protecting smart contracts, utilizing only non-interactive zero knowledge. By design, contracts are structured in a way that gives developers a clear separation between the personal data that stays on the user’s machine, and the data that is processed publicly on-chain. 
 
-At the core of the Kachina model is the concept of bridging the gap between the blockchain and users' local machines. This is achieved by representing the system through two distinct [states](/docs/learn/04-glossary.mdx#state): 
+At the core of the Kachina model is the concept of bridging the gap between the blockchain and users' local machines. This is achieved by representing the system through two distinct [states](/docs/learn/glossary.mdx#state): 
 
 - a public state, which resides on the blockchain and is accessible to all participants
 - a private state, which exists locally on each user's machine. 


### PR DESCRIPTION
I updated the link to the `glossary.mdx` file, since the previous link (`04-glossary.mdx`) did not exist.