### PR TITLE
Added a scroll bar to the sidebar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -96,6 +96,17 @@ h6 {
   padding-top: 0 !important;
 }
 
+@media (min-width: 997px) {
+  .theme-doc-sidebar-container {
+    position: sticky;
+    top: 0;
+  }
+
+  .theme-doc-sidebar-container > div {
+    overflow-y: auto;
+  }
+}
+
 [data-theme="dark"] .sidebar,
 [data-theme="dark"] .theme-doc-sidebar-container {
   border-right-color: #374151 !important;


### PR DESCRIPTION
If you expand the contents in the sidebar they open under the footer, and it's impossible to access those sections once you expand the menu. I added a scroll bar once the sections expand, so devs can still scroll down to see those sections.