### PR TITLE
fix: update GitHub Actions workflows to use yarn@4.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Activate Yarn 4 via Corepack
         run: |
           corepack enable
-          corepack prepare yarn@4.10.3 --activate
+          corepack prepare yarn@4.12.0 --activate
           yarn -v
         env:
           # Ensure we don't pick up any global Yarn 1.x

--- a/.github/workflows/playwright-visual-regression.yml
+++ b/.github/workflows/playwright-visual-regression.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Enable Corepack
         run: |
           corepack enable
-          corepack prepare yarn@4.10.3 --activate
+          corepack prepare yarn@4.12.0 --activate
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Enable Corepack
         run: |
           corepack enable
-          corepack prepare yarn@4.10.3 --activate
+          corepack prepare yarn@4.12.0 --activate
       - name: Install Vercel CLI
         run: npm install --global vercel@canary
       - name: Pull Vercel Environment Information

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -32,7 +32,9 @@ jobs:
         with:
           node-version: 22
       - name: Enable Corepack
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare yarn@4.12.0 --activate
       - name: Install Vercel CLI
         run: npm install --global vercel@canary
       - name: Pull Vercel Environment Information


### PR DESCRIPTION
## Fix CI Error: Yarn Version Mismatch

Resolves CI failures after merging to main where workflows failed with:
```
error This project's package.json defines "packageManager": "yarn@4.12.0". 
However the current global version of Yarn is 1.22.22.
```

---

### Key Changes

Updated all GitHub Actions workflows to use `yarn@4.12.0` (matching `package.json`) via Corepack:

- **`.github/workflows/prod.yml`** - Added `corepack prepare yarn@4.12.0 --activate` to properly set up Yarn before Vercel commands
- **`.github/workflows/build.yml`** - Updated from `yarn@4.10.3` to `yarn@4.12.0`
- **`.github/workflows/pr.yml`** - Updated from `yarn@4.10.3` to `yarn@4.12.0`
- **`.github/workflows/playwright-visual-regression.yml`** - Updated from `yarn@4.10.3` to `yarn@4.12.0`

---

### Root Cause

The project's `package.json` specifies `"packageManager": "yarn@4.12.0"`, which requires Corepack to be enabled with that exact version. The CI workflows were either:
1. Not preparing a specific Yarn version (defaulting to system Yarn 1.22.22), or
2. Using an outdated version (`yarn@4.10.3`)

This caused Corepack to reject the version mismatch and fail the build.

---

### Solution

All workflows now explicitly activate `yarn@4.12.0` using:
```yaml
- name: Enable Corepack
  run: |
    corepack enable
    corepack prepare yarn@4.12.0 --activate
```

This ensures consistent dependency management across all CI environments and matches the version declared in `package.json`.

---

### Testing

- [x] Workflows updated and committed
- [x] Changes follow existing workflow patterns
- [x] Version matches `package.json` specification

---

### Backward Compatibility

✅ **100% backward compatible** - This change only affects CI/CD environments, not runtime behavior. All workflows will now use the correct Yarn version as specified in `package.json`.