### PR TITLE
chore: Remove stray URL text from module 4

### DIFF
--- a/academy/module-4.mdx
+++ b/academy/module-4.mdx
@@ -189,8 +189,7 @@ The UC model essentially future-proofs the security: developers can build on Kac
 
 Now that we’ve covered the what and why, let’s look at how Kachina works in practice (conceptually). The Kachina protocol introduces a specific architecture for smart contracts to achieve privacy:
 
-* A Kachina-based smart contract splits its state into two parts: a public state and a private state​
-docs.midnight.network. The public state resides on-chain (visible to everyone on the blockchain), while each participant in the contract maintains their own private state off-chain (visible only to themselves). For example, the public state might include encrypted outputs, commitment identifiers, or public keys, whereas the private state could be a user’s secret data like their balance, private inputs, or keys.
+* A Kachina-based smart contract splits its state into two parts: a public state and a private state​. The public state resides on-chain (visible to everyone on the blockchain), while each participant in the contract maintains their own private state off-chain (visible only to themselves). For example, the public state might include encrypted outputs, commitment identifiers, or public keys, whereas the private state could be a user’s secret data like their balance, private inputs, or keys.
 
 * The contract is designed such that any update (transaction) will update both the public and private state together in a coordinated way​. When a user wants to perform an action on the contract, they do two things: (1) update their own private state according to the action (for instance, subtract the amount they want to spend from their secret balance), and (2) prepare a zero-knowledge proof that this private update is valid with respect to the contract’s rules.
 


### PR DESCRIPTION
This PR fixes a broken sentence in Module 4 documentation where a stray URL text was interrupting the flow.