### PR TITLE
Bboard tutorial: Use `compact compile` instead of `compactc`

### DIFF
--- a/docs/develop/tutorial/3-creating/bboard-contract.mdx
+++ b/docs/develop/tutorial/3-creating/bboard-contract.mdx
@@ -257,7 +257,7 @@ and that your current directory is the
 `contract` directory when you run the command):
 
 ```shell
-compactc src/bboard.compact src/managed/bboard
+compact compile src/bboard.compact src/managed/bboard
 ```
 
 You should see a message about the circuit complexity for each of the


### PR DESCRIPTION
Updates tutorial instructions to use `compact compile` instead of `compactc` command to compile the contract. My understanding is that`compactc` is the old, low-level compiler executable. The current recommended way based on the linked instructions is to use the compact tool with the `compile` subcommand. 

Current state (needs update):
<img width="1172" height="271" alt="Screenshot 2025-12-28 at 10 40 16 AM" src="https://github.com/user-attachments/assets/2b9b7e76-64b5-413b-a488-c198d5df8cfa" />

---

The linked instructions to "Running Midnight Compact compiler" say:
<img width="845" height="366" alt="Screenshot 2025-12-28 at 10 43 41 AM" src="https://github.com/user-attachments/assets/82c5bb5d-0b97-4e1d-961b-200eb531f211" />
