### PR TITLE
Add the onchain-runtime JS dependency

### DIFF
--- a/docs/develop/how-to/migrate-from-testnet-02-to-preview.mdx
+++ b/docs/develop/how-to/migrate-from-testnet-02-to-preview.mdx
@@ -148,6 +148,7 @@ Update your `package.json` with the following dependencies for Preview network.
 ```json
 {
   "@midnight-ntwrk/compact-runtime": "0.11.0-rc.1",
+  "@midnight-ntwrk/onchain-runtime-v1" "1.0.0-alpha.5",
   "@midnight-ntwrk/midnight-js-contracts": "3.0.0-alpha.11",
   "@midnight-ntwrk/midnight-js-http-client-proof-provider": "3.0.0-alpha.11",
   "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "3.0.0-alpha.11",


### PR DESCRIPTION
For the current (Midnight ledger 6.1) version of Preview we will need to fix the onchain-runtime dependency to avoid incorrectly pulling in a ledger 6.2 version. This will not be generally needed, it is "one time only" for the current Preview environment.