### PR TITLE
docs: add documentation on private state

### DIFF
--- a/docs/learn/understanding-midnights-technology/private-state.mdx
+++ b/docs/learn/understanding-midnights-technology/private-state.mdx
@@ -1,0 +1,189 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) 2026 Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+id: private-state
+title: Private State
+---
+
+# Private State
+
+Midnight introduces an innovative, privacy-first contract model that separates data into
+public state, visible on-chain, and private state, encrypted and wholly owned by the user.
+This section describes key concepts for managing private state in Midnight contracts.
+
+## What is Private State?
+
+Private state is off-chain data accessible only to a specific user or DApp instance. Unlike a contract state, it is not stored on-chain and remains private. It lives off-chain on each user’s machine. Each participant maintains their own private data locally, separate from the shared public blockchain. Private state is stored and managed per contract instance via interfaces like PrivateStateProvider those that read/write per‑contract private states on the client. Private state remains local to each DApp instance and varies per user. Contracts specify the types for functions that interact with private state, sometimes referred to as witness functions, and define how the private-state data is structured and accessed. Examples of private states are
+
+- Secret balances, keys, or credentials
+
+- Local caches of commitments or encrypted outputs
+
+- Any contract-specific local data your DApp needs
+
+## Managing Private State in Your DApp
+
+In Midnight, a private state is a user-specific, encrypted portion of a smart contract that never leaves the user’s device. It allows decentralized applications to handle sensitive information while ensuring privacy. Unlike public state, which is visible on-chain, private state is used with zero-knowledge
+proofs to verify contract actions without revealing the actual data.
+
+This section outlines the mechanisms for defining private state and accessing it through witness functions in Midnight.
+
+### Defining private state
+
+Before a DApp can use private state, its structure must be declared in the Compact contract. Private state is an optional feature that allows each user or DApp instance to maintain off-chain data locally. Not all DApps require private state.
+
+The private state type is specified in Compact code, and the Compact compiler automatically generates a corresponding TypeScript type. This ensures type-safe interaction with the contract API and helps prevent errors when reading or updating private data.
+
+:::warning[Important]
+When updating private state, always return a new state object instead of mutating the existing one. This ensures changes are predictable, prevents unintended side effects, and allows the DApp framework to correctly detect and propagate updates. Mutating state in place can lead to inconsistencies and bugs.
+:::
+
+For example, in a bulletin board DApp, each user’s private state might store a secret key:
+
+```ts
+export type BBoardPrivateState = {
+  secretKey: Uint8Array;
+};
+
+export function createBBoardPrivateState(
+  secretKey: Uint8Array
+): BBoardPrivateState {
+  return { secretKey };
+}
+```
+
+Private state is defined locally on each user’s machine and is never visible on-chain. Its type is derived from the contract’s witness functions, ensuring that the DApp always aligns with the contract’s structure.
+
+### Accessing private state with witness functions
+
+Once private state is defined, the contract needs a secure way to access it. In Midnight, **witness functions** provide this access while keeping the data confidential.
+
+In the bulletin board DApp, the `localSecretKey` witness function passes the secret key into the circuit during zero-knowledge proof execution:
+
+```ts
+import { createBBoardWitnesses } from "midnight-sdk";
+
+export const witnesses = createBBoardWitnesses<BBoardPrivateState>({
+  localSecretKey: ({ privateState }) => {
+    return [privateState, privateState.secretKey];
+  }
+});
+```
+
+The function receives a WitnessContext, which contains the ledger, private state, and contract address. It returns a tuple consisting of the updated private state and the value provided to the circuit. In this example, the private state remains unchanged, and the secret key is used during proof generation without being exposed publicly.
+
+## Creating Private State in a DApp
+
+This section describes how private state is created and managed on the user’s side in a Midnight DApp. Private state is maintained entirely off-chain and is owned by the user or DApp instance, not the contract.
+
+### 1. Using the Generated Private State Type
+
+When a Compact contract is compiled, the compiler generates a corresponding private state type based on the contract’s witness functions. This type is used by the DApp to ensure type-safe interaction with the contract.
+
+You should not manually define the private state type. Instead, import and use the generated type.
+
+For example, in a bulletin board DApp, the private state may consist of a secret key:
+
+```ts
+export type BBoardPrivateState = {
+  secretKey: Uint8Array;
+};
+```
+
+A helper function can be used to instantiate the private state:
+
+```ts
+export function createBBoardPrivateState(
+  secretKey: Uint8Array
+): BBoardPrivateState {
+  return { secretKey };
+}
+```
+
+:::caution[Common pitfall]
+The `BBoardPrivateState` type is generated during contract compilation. Defining it manually can lead to mismatches between the DApp and the contract.
+:::
+
+### 2. Initializing Private State
+
+Private state must be created or retrieved when a user deploys or joins a contract. Common patterns include generating a random secret key or restoring an existing private state from storage.
+
+Contracts cannot create or store private state. All private state initialization logic resides in the DApp.
+
+### 3.Storing Private State Locally
+
+Private state is stored locally on the user’s device using a PrivateStateProvider. This allows the DApp to persist and retrieve private state across sessions.
+
+For persistent storage, a LevelDB-based provider can be used:
+
+```ts
+const provider = levelPrivateStateProvider<BBoardPrivateState>({
+  privateStateStoreName: "bboard-private-state"
+});
+
+await provider.set("bboard-private-state", myPrivateState);
+```
+
+For testing or temporary usage, an in-memory provider is also available:
+
+```ts
+const provider = inMemoryPrivateStateProvider<BBoardPrivateState>();
+await provider.set("bboard-private-state", myPrivateState);
+```
+
+### 4. Accessing Private State in Witness Functions
+
+While witness functions are declared in the Compact contract, their implementations are provided by the DApp. During transaction execution, a witness function receives the current private state and returns both the updated private state and the value required by the circuit.
+
+Example witness implementation:
+
+```ts
+export const witnesses = createBBoardWitnesses<BBoardPrivateState>({
+  localSecretKey: ({ privateState }) => {
+    return [privateState, privateState.secretKey];
+  }
+});
+```
+
+In this example, the witness function returns the unchanged private state along with the secret key. The secret key is used during proof generation without being exposed on-chain.
+
+## Encoding Private State at the DApp Level
+
+To encode private state at the DApp level, you are responsible for choosing how to represent and persist it. The core pattern is:
+
+1. Consume the TypeScript type for your private state, generated automatically from the Compact contract code.
+
+```ts
+// Example from the bulletin board DApp
+export type BBoardPrivateState = {
+  secretKey: Uint8Array;
+};
+```
+
+2. Provide witness functions that read/update this state:
+
+```ts
+export const witnesses = createBBoardWitnesses<BBoardPrivateState>({
+  localSecretKey: ({ privateState }) => {
+    return [privateState, privateState.secretKey];
+  }
+});
+```
+
+The Compact contract defines the structure of privateState, and the compiler generates a corresponding TypeScript type for the DApp. The Midnight toolchain does not alter the contract’s internal encoding.
+
+3. As long as the DApp can reconstruct the required in-memory type and pass it into the witness context, the exact storage format is flexible. The documentation does not prescribe or standardize how this data must be stored. Midnight’s libraries expose a typed key-value store interface for working with private states:
+
+```ts
+interface PrivateStateProvider<
+  PSI extends PrivateStateId = PrivateStateId,
+  PS = any
+> {
+  get(id: PSI): Promise<PS | null>;
+  set(id: PSI, state: PS): Promise<void>;
+  remove(id: PSI): Promise<void>;
+  clear(): Promise<void>;
+  // plus signing key helpers
+}
+``;
+```

--- a/sidebars.main.js
+++ b/sidebars.main.js
@@ -65,7 +65,8 @@ module.exports = {
             "learn/understanding-midnights-technology/web3",
             "learn/understanding-midnights-technology/zero-knowledge-proofs",
             "learn/understanding-midnights-technology/kachina",
-            "learn/understanding-midnights-technology/zswap"
+            "learn/understanding-midnights-technology/zswap",
+            "learn/understanding-midnights-technology/private-state"
           ]
         },
 


### PR DESCRIPTION
This PR introduces detailed documentation on private state in Midnight, covering how it is represented, managed, and accessed within DApps.