### PR TITLE
chore: upgrade TypeScript to ^5.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "prettier": "^3.8.1",
     "tailwindcss": "^4.1.18",
     "three": "^0.182.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.9.3",
     "yaml-loader": "^0.9.0"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary

Bump TypeScript from ^5.2.2 to ^5.9.3 (latest stable) for improved type checking, performance, and language features.

## Changes

- `package.json`: `typescript` ^5.2.2 → ^5.9.3