### PR TITLE
ci: update scanner

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  scan:
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
Use latest versions of security scanners. scan is now not a sub-action.