### PR TITLE
fixed broken links

### DIFF
--- a/docs/compact/writing.mdx
+++ b/docs/compact/writing.mdx
@@ -29,7 +29,7 @@ enum State {
 ```
 
 In addition to the `enum` declaration, custom data can also be defined with
-`struct`s.  Details can be found in the 
+`struct`s. Details can be found in the
 language reference.
 
 ## The `ledger` section
@@ -68,7 +68,7 @@ circuit publicKey(round: Field, sk: Bytes<32>): Bytes<32> {
 
 In addition to the `ledger` section, the `constructor` also demonstrates basic
 interaction with the state contained in it, using the field names to refer to
-the items in the ledger's state. Many ledger types also support *operations* as
+the items in the ledger's state. Many ledger types also support _operations_ as
 demonstrated in `clear`.
 
 ## The `circuit` definitions
@@ -76,8 +76,8 @@ demonstrated in `clear`.
 The example above already demonstrates use of a `circuit` to calculate the
 `publicKey` of a user. A `circuit` in Compact is equivalent to a function in many
 programming languages, but it is restricted to fixed computational bounds at
-compile time.  A smart contract's `circuit`s can also be its main entry points;
-they are what users can call directly in transactions. Of the three entry points mentioned above, `get` is *unrestricted* and is simply implemented as
+compile time. A smart contract's `circuit`s can also be its main entry points;
+they are what users can call directly in transactions. Of the three entry points mentioned above, `get` is _unrestricted_ and is simply implemented as
 follows:
 
 ```compact title=lock.compact
@@ -96,9 +96,9 @@ of `circuit`s.
 
 The third context mentioned was the local machine of the user. This is
 explicitly programmable in the form of the DApp running on the
-user's machine.  Compact can 'call out' to the local context through
-*witnesses*[^1], which are declared in a similar way to circuits. In this case, retrieving a user's
-*secret key* requires such a witness, because the secret must be kept local to a user's
+user's machine. Compact can 'call out' to the local context through
+_witnesses_[^1], which are declared in a similar way to circuits. In this case, retrieving a user's
+_secret key_ requires such a witness, because the secret must be kept local to a user's
 machine.
 
 The code for this follows:
@@ -194,35 +194,37 @@ export circuit clear(): [] {
 
 It may not be immediately apparent what is held confidential in this example
 and what is enforced in the contract. Thankfully, both are well-defined:
+
 - all data that is not a ledger field and is not an argument or return value of a ledger operation is kept confidential
 - all computation that is not done in a `witness` function is enforced to be
   correct.
 
 In particular, observe that this keeps the `secretKey` output confidential,
-while enforcing that *its hash* is the correct value in the case of `clear`.
+while enforcing that _its hash_ is the correct value in the case of `clear`.
 
 This is also the reason for the `round` parameter: The `pk` "public key"
-*isn't* confidential, and would allow linkability between the same user
+_isn't_ confidential, and would allow linkability between the same user
 publishing data in multiple rounds. By adding a round parameter into the public
 key computation, this linkability is broken.
 
-Despite the terms "secret key" and "public key", these two keys are *not*
+Despite the terms "secret key" and "public key", these two keys are _not_
 public key cryptography: they are simply a binary string and its hash. This is
 due to zero-knowledge circuits being able to have similar effects to digital
 signatures, relying only on the preimage resistance of hashes.
 
 This pattern of hashing an arbitrary binary string and using it as a key is
 quite powerful. A similar concept that can be very useful is the use of
-*commitment schemes*,
+_commitment schemes_,
 where arbitrary data is hashed together with a random
-*nonce*. The result can be safely placed into the ledger's state, without
-revealing the original data. (Note that the nonce *must* not be reused. If it
+_nonce_. The result can be safely placed into the ledger's state, without
+revealing the original data. (Note that the nonce _must_ not be reused. If it
 is, you can link the commitments with the same nonces and values.) At a later
 point, the commitment can be "opened" by revealing the value and nonce, or a
-contract can simply prove (`assert`) that it *has* the correct value and nonce,
+contract can simply prove (`assert`) that it _has_ the correct value and nonce,
 without ever revealing them.
 
 The `CompactStandardLibrary` module provides the following circuits for such uses:
+
 ```compact title=standard-library.compact
 circuit transientHash<T>(value: T): Field;
 circuit transientCommit<T>(value: T, rand: Field): Field;
@@ -232,18 +234,18 @@ circuit persistentCommit<T>(value: T, rand: Bytes<32>): Bytes<32>;
 
 The `*Hash` variants are the basic hash function, with `*Commit` being a
 commitment function to arbitrary data. The `transient*` functions should only
-be used when the values are *not* kept in state, while `persistent*` outputs
+be used when the values are _not_ kept in state, while `persistent*` outputs
 being suitable for storage in a contract's `ledger` state.
 
 ## Next steps
 
 This section continues with a more detailed overview of the Compact language.
-Alternatively, you may wish to jump to a [more detailed example](../tutorials/beginner/bboard-contract.mdx)
+Alternatively, you may wish to jump to a [more detailed example](../examples/dapps/bboard.mdx)
 that showcases some more interesting things you can do with a DApp on Midnight.
 While this section has focused on the Compact language,
 the section about how Midnight works
 provides more detail about Midnight's ledger and how it functions.
 
-[^1] The name *witness* comes from zero-knowledge literature; the etymology is
+[^1] The name _witness_ comes from zero-knowledge literature; the etymology is
 roughly that it's the evidence you need to believe a statement. In this
 example, it's the evidence you need to believe that a `clear` was permissible.

--- a/docs/examples/dapps/bboard.mdx
+++ b/docs/examples/dapps/bboard.mdx
@@ -10,7 +10,7 @@ toc_max_heading_level: 2
 
 # Bulletin board DApp
 
-The bulletin board contract demonstrates privacy-preserving smart contracts on Midnight using the Compact language. 
+The bulletin board contract demonstrates privacy-preserving smart contracts on Midnight using the Compact language.
 This example shows how to create a contract that allows users to post and remove messages while protecting poster identity through Zero Knowledge (ZK) proofs.
 
 The bulletin board example is a privacy-focused DApp that introduces key Midnight concepts:
@@ -49,7 +49,7 @@ example-bboard/
 
 ## The bulletin board contract
 
-The bulletin board contract is written in Compact. It demonstrates how to build a privacy-preserving 
+The bulletin board contract is written in Compact. It demonstrates how to build a privacy-preserving
 application where users can prove ownership of posted content without revealing their identity.
 
 Here is the complete contract:
@@ -202,7 +202,7 @@ You should see the following output:
 > compact compile src/bboard.compact src/managed/bboard
 
 Compiling 2 circuits:
-  circuit "post" (k=13, rows=4569)  
+  circuit "post" (k=13, rows=4569)
   circuit "takeDown" (k=13, rows=4580)
 ```
 
@@ -243,7 +243,7 @@ npm run preprod-remote
 The script launches the CLI and connects to the Preprod network. You should see the following output:
 
 ```
- Starting test environment... 
+ Starting test environment...
  Performing env health check
  Connected to indexer https://indexer.preprod.midnight.network/ready: ""
  Connected to proof server http://127.0.0.1:6300/health: {"status":"ok"}
@@ -409,6 +409,7 @@ What message do you want to post? Welcome to Midnight
 ```
 
 The CLI:
+
 1. Generates a cryptographic commitment to your identity using your secret key
 2. Creates a ZK proof proving you followed the contract rules
 3. Submits the proof to Preprod
@@ -456,6 +457,7 @@ Which would you like to do? 2
 ```
 
 The CLI:
+
 1. Regenerates your cryptographic commitment using your secret key and the current sequence number
 2. Proves it matches the stored `owner` value
 3. Submits a ZK proof of this verification
@@ -498,4 +500,4 @@ The CLI safely shuts down the wallet and stops the test environment.
 Now that you understand the bulletin board example:
 
 - **Explore the GitHub repository**: [Bulletin board repository](https://github.com/midnightntwrk/example-bboard)
-- **Build the contract yourself**: Learn how to [build the bulletin board smart contract](../tutorials/beginner/bboard/smart-contract).
+- **Build the contract yourself**: Learn how to [build the bulletin board smart contract](../../tutorials/beginner/bboard/smart-contract).


### PR DESCRIPTION

changed

https://docs.midnight.network/examples/tutorials/beginner/bboard/smart-contract

to: 
https://docs.midnight.network//tutorials/beginner/bboard/smart-contract

changed:

https://docs.midnight.network/tutorials/beginner/bboard-contract.mdx

to:

https://docs.midnight.network/examples/dapps/bboard