### PR TITLE
fix: examples: add calc context

### DIFF
--- a/docs/examples/contracts/calculator.mdx
+++ b/docs/examples/contracts/calculator.mdx
@@ -8,6 +8,12 @@ description: Example contract for math operations
 toc_max_heading_level: 2
 ---
 
+This Compact contract implements a simple calculator. It offers demonstration of the following features:
+- Witness function
+- On-chain verification of off-chain compute
+
+Notice that `divMod` only has the declaration of the function signature. Its logic is implemented in the Typescript frontend and is unknown to contract, though we can enforce expected execution through `assert` statements in `divide`.
+
 ```compact
 pragma language_version 0.21;
 


### PR DESCRIPTION
- Add brief context about the purpose of the contract