### PR TITLE
Fix: Update Node documentation to support binary/source distribution and current networks

### DIFF
--- a/docs/nodes/_run-a-validator/index.mdx
+++ b/docs/nodes/_run-a-validator/index.mdx
@@ -1,7 +1,7 @@
 ---
 ---
 
-import vidThumbnail from './images/vid_thumb_become_producer.png';
+import vidThumbnail from "./images/vid_thumb_become_producer.png";
 
 # Become a Midnight Block Producer
 
@@ -20,19 +20,23 @@ This documentation is designed to guide you through the process of becoming a Mi
 ## Prerequisites
 
 #### Must-have skills
+
 - Proficiency in setting up, running, and monitoring blockchain nodes consistently
 - Proficiency in CLI usage, system administration, and networking
 - Experience with blockchain technologies, especially Cardano stake pool operations
 
 #### Nice-to-have skills
+
 - Familiarity with scripting languages (e.g., Bash, Python) for automation
 - Understanding of security best practices for blockchain infrastructure
 
 #### Must-have gear
+
 - Reliable internet connection with minimal downtime. 50 MB/s or more is sufficient.
 - Adequate hardware to run a full node (CPU, RAM, and storage requirements as per the latest documentation)
 
 #### Nice-to-have gear
+
 - Redundant internet connection to ensure high availability
 - Backup power supply to prevent downtime during power outages
 
@@ -48,7 +52,7 @@ To let Midnight evolve without resetting the chain, new versions of node softwar
 
 :::
 
-##  Midnight Block Production Overview
+## Midnight Block Production Overview
 
 ```mermaid
 sequenceDiagram
@@ -129,8 +133,8 @@ Most node operators manage their servers and infrastructure remotely from their 
 
 If you are using WSL, then please use:
 
-* Ubuntu 22.04 (or equivalent)
-    * [GLIBC](https://www.gnu.org/software/libc/) 2.35
+- Ubuntu 22.04 (or equivalent)
+  - [GLIBC](https://www.gnu.org/software/libc/) 2.35
 
 Check current GLIBC version in WSL:
 
@@ -152,16 +156,15 @@ These are estimated system requirements for each service used within Midnight va
 
 Here's the updated table with the versions filled in:
 
-| Service            | Quantity | CPU `testnet` | CPU `mainnet` | Memory `testnet` | Memory `mainnet` | Storage `testnet`  | Storage `mainnet`        |
-|--------------------|----------|---------------|---------------|------------------|------------------|-------------------|--------------------------|
-| **Cardano DB Sync**| 1        | 4 VCPU        | 4 VCPU        | 32 GB RAM        | 32 GB RAM        | 20 GB free         | 320 GB free              |
-| **Cardano Node** | 2        | 2 VCPU        | 4 VCPU        | 4 GB RAM         | 16 GB RAM        | 20 GB free         | 250 GB free              |
-| **PostgreSQL** | 1        | 0.5 VCPU      | 1 VCPU        | 1 GB RAM         | 1 GB RAM         | -                  | -                        |
-| **Midnight Node** | 1        | 4 VCPU        | 8 VCPU        | 16 GB RAM        | 32 GB RAM        | 40 GB free         | TBD                      |
-| **Ogmios** | 1        | 0.5 VCPU      | 1 VCPU        | 1 GB RAM         | 2 GB RAM         | -                  | -                        |
+| Service             | Quantity | CPU `testnet` | CPU `mainnet` | Memory `testnet` | Memory `mainnet` | Storage `testnet` | Storage `mainnet` |
+| ------------------- | -------- | ------------- | ------------- | ---------------- | ---------------- | ----------------- | ----------------- |
+| **Cardano DB Sync** | 1        | 4 VCPU        | 4 VCPU        | 32 GB RAM        | 32 GB RAM        | 20 GB free        | 320 GB free       |
+| **Cardano Node**    | 2        | 2 VCPU        | 4 VCPU        | 4 GB RAM         | 16 GB RAM        | 20 GB free        | 250 GB free       |
+| **PostgreSQL**      | 1        | 0.5 VCPU      | 1 VCPU        | 1 GB RAM         | 1 GB RAM         | -                 | -                 |
+| **Midnight Node**   | 1        | 4 VCPU        | 8 VCPU        | 16 GB RAM        | 32 GB RAM        | 40 GB free        | TBD               |
+| **Ogmios**          | 1        | 0.5 VCPU      | 1 VCPU        | 1 GB RAM         | 2 GB RAM         | -                 | -                 |
 
-
-:::tip 
+:::tip
 
 An existing Cardano relay node can be repurposed for `cardano-db-sync` if the operational setup permits.
 
@@ -171,8 +174,8 @@ An existing Cardano relay node can be repurposed for `cardano-db-sync` if the op
 
 Midnight-node uses partner-chains CLI commands which require on an Ogmios connect. While you may run Ogmios locally, we provide public endpoints for the service.
 
-* [ogmios.preview.midnight.network](https://ogmios.preview.midnight.network)
-* [ogmios.preprod.midnight.network](https://ogmios.preprod.midnight.network)
+- [ogmios.preview.midnight.network](https://ogmios.preview.midnight.network)
+- [ogmios.preprod.midnight.network](https://ogmios.preprod.midnight.network)
 
 ### Network and Security Considerations for Testnet:
 

--- a/docs/nodes/_run-a-validator/index.mdx
+++ b/docs/nodes/_run-a-validator/index.mdx
@@ -169,9 +169,10 @@ An existing Cardano relay node can be repurposed for `cardano-db-sync` if the op
 
 ## Public endpoints
 
-Midnight-node uses partner-chains CLI commands which require on an Ogmios connect. While you may run Ogmios locally, we provide a public endpoint for the service.
+Midnight-node uses partner-chains CLI commands which require on an Ogmios connect. While you may run Ogmios locally, we provide public endpoints for the service.
 
-* [ogmios.testnet-02.midnight.network](https://ogmios.testnet-02.midnight.network)
+* [ogmios.preview.midnight.network](https://ogmios.preview.midnight.network)
+* [ogmios.preprod.midnight.network](https://ogmios.preprod.midnight.network)
 
 ### Network and Security Considerations for Testnet:
 

--- a/docs/nodes/_run-a-validator/step-1.mdx
+++ b/docs/nodes/_run-a-validator/step-1.mdx
@@ -13,8 +13,8 @@ To embark on the path of becoming a Midnight validator, one must either be, or b
 
 | Cardano env. | Status | Midnight env.
 |----------|----------|----------|
-| `preview` | ✅ | `testnet-02` |
-| `preprod` | ❌ | N/A |
+| `preview` | ✅ | `preview` |
+| `preprod` | ✅ | `preprod` |
 | `mainnet` | ❌ | N/A |
 
 ## Become a Cardano SPO

--- a/docs/nodes/_run-a-validator/step-1.mdx
+++ b/docs/nodes/_run-a-validator/step-1.mdx
@@ -11,11 +11,11 @@ To embark on the path of becoming a Midnight validator, one must either be, or b
 
 ## Supported environments
 
-| Cardano env. | Status | Midnight env.
-|----------|----------|----------|
-| `preview` | ✅ | `preview` |
-| `preprod` | ✅ | `preprod` |
-| `mainnet` | ❌ | N/A |
+| Cardano env. | Status | Midnight env. |
+| ------------ | ------ | ------------- |
+| `preview`    | ✅     | `preview`     |
+| `preprod`    | ✅     | `preprod`     |
+| `mainnet`    | ❌     | N/A           |
 
 ## Become a Cardano SPO
 
@@ -24,8 +24,8 @@ To embark on the path of becoming a Midnight validator, one must either be, or b
 1. Cardano node version [`10.1.4`](https://github.com/IntersectMBO/cardano-node/releases/tag/10.1.4). Please use this version.
 2. 500 `tAda` + fee for stake pool pledge.
 3. A UTXO for the Midnight validator registration fee, with its `payment.skey`.
-3. SPO `cold.skey` will also be needed within the Midnight validator registration process.
-4. Air-gapped device for secret storage (optional for testnets).
+4. SPO `cold.skey` will also be needed within the Midnight validator registration process.
+5. Air-gapped device for secret storage (optional for testnets).
 
 :::info
 
@@ -48,5 +48,5 @@ graph TD;
 
 ---
 
--   [Preview testnet configuration files](https://book.world.dev.cardano.org/env-preview.html#configuration-files)
--   [Testnets faucet to request tADA](https://docs.cardano.org/cardano-testnet/tools/faucet/)
+- [Preview testnet configuration files](https://book.world.dev.cardano.org/env-preview.html#configuration-files)
+- [Testnets faucet to request tADA](https://docs.cardano.org/cardano-testnet/tools/faucet/)

--- a/docs/nodes/boot-node.mdx
+++ b/docs/nodes/boot-node.mdx
@@ -19,25 +19,77 @@ A **boot node** is a specialized type of node that helps other nodes connect to 
 
 Before setting up your Midnight boot node, ensure you have the following:
 
-* [Docker](https://docs.docker.com/engine/install/) installed and configured.
 * [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
 * Sufficient resources (CPU, memory, and storage).
+* Either a precompiled binary or Rust toolchain (for building from source).
 
 ## Setting Up a Boot Node
 
-### Step 1: Configure PostgreSQL Database
+### Option 1: Using Binary Distribution (Recommended)
 
-Set up a PostgreSQL instance with the following parameters:
+The binary distribution method is the recommended approach for most users.
 
-* **Host:** PostgreSQL server address.
-* **Port:** Default 5432.
-* *Username:** Database user.
-* **Password:** Database password.
-* **Database Name:** Name of the database (e.g., cexplorer).
+#### Step 1: Download the Binary
 
-### Step 2: Run the Docker Command for a Boot Node
+Download the latest Midnight node binary from the [GitHub releases page](https://github.com/midnight-network/node/releases).
 
-Use the following Docker command to set up your boot node:
+```bash
+# Example for Linux x86_64
+wget https://github.com/midnight-network/node/releases/download/v<VERSION>/midnight-node-x86_64-linux
+chmod +x midnight-node-x86_64-linux
+```
+
+Replace `<VERSION>` with the required version according to the [release compatibility matrix](../../relnotes/support-matrix).
+
+#### Step 2: Run the Boot Node
+
+To start a boot node for a network of your choice:
+
+```bash
+./midnight-node-x86_64-linux \
+  --chain preview \
+  --base-path ./chain-data \
+  --listen-addr /ip4/0.0.0.0/tcp/30333
+```
+
+Or for the preprod network:
+
+```bash
+./midnight-node-x86_64-linux \
+  --chain preprod \
+  --base-path ./chain-data \
+  --listen-addr /ip4/0.0.0.0/tcp/30333
+```
+
+### Option 2: Building from Source
+
+For users who prefer to build from source:
+
+#### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/midnight-network/node.git
+cd node
+```
+
+#### Step 2: Build the Binary
+
+```bash
+cargo build --release
+```
+
+#### Step 3: Run the Boot Node
+
+```bash
+./target/release/midnight-node \
+  --chain preview \
+  --base-path ./chain-data \
+  --listen-addr /ip4/0.0.0.0/tcp/30333
+```
+
+### Option 3: Docker (Alternative)
+
+If you prefer containerized deployment:
 
 ```bash
 docker run \
@@ -45,28 +97,16 @@ docker run \
   --platform linux/amd64 \
   -p 30333:30333 \
   -v midnight-data:/node \
-  -e MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:<VERSION>" \
   -e BASE_PATH="./node/chain/" \
-  -e CFG_PRESET="testnet" \
   midnightnetwork/midnight-node:<VERSION> \
+  --chain=preview \
   --listen-addr /ip4/0.0.0.0/tcp/30333 \
-  --bootnodes \
-  /dns/boot-node-01.testnet-02.midnight.network/tcp/30333/ws/p2p/12D3KooWMjUq13USCvQR9Y6yFzYNYgTQBLNAcmc8psAuPx2UUdnB \
   --no-private-ip
 ```
 
-Replace `<VERSION>` with the required version of the node according to the [release compatibility matrix](../../relnotes/support-matrix).
-
 ## Known Environment Boot Nodes
 
-Use the corresponding boot nodes for your target environment.
-
-### Preprod
-
-```bash
---bootnodes /dns/bootnode-1.preprod.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5 \
---bootnodes /dns/bootnode-2.preprod.midnight.network/tcp/30333/ws/p2p/12D3KooWNrUBs22FfmgjqFMa9ZqKED2jnxwsXWw5E4q2XVwN35TJ
-```
+Use the corresponding boot nodes for your target environment when starting a fallback or regular node.
 
 ### Preview
 
@@ -75,13 +115,22 @@ Use the corresponding boot nodes for your target environment.
 --bootnodes /dns/bootnode-2.preview.midnight.network/tcp/30333/ws/p2p/12D3KooWHqFfXFwb7WW4jwR8pr4BEf562v5M6c8K3CXAJq4Wx6ym
 ```
 
+### Preprod
+
+```bash
+--bootnodes /dns/bootnode-1.preprod.midnight.network/tcp/30333/ws/p2p/12D3KooWQxxUgq7ndPfAaCFNbAxtcKYxrAzTxDfRGNktF75SxdX5 \
+--bootnodes /dns/bootnode-2.preprod.midnight.network/tcp/30333/ws/p2p/12D3KooWNrUBs22FfmgjqFMa9ZqKED2jnxwsXWw5E4q2XVwN35TJ
+```
+
 ## Verifying the Node
 
 ### Check Logs
 
-Monitor the node's logs to ensure it syncs with the network:
+Monitor the node's output to ensure it's running:
 
 ```bash
+# Binary output logs to stdout
+# For Docker:
 docker logs -f <node-name>
 ```
 

--- a/docs/nodes/boot-node.mdx
+++ b/docs/nodes/boot-node.mdx
@@ -19,9 +19,9 @@ A **boot node** is a specialized type of node that helps other nodes connect to 
 
 Before setting up your Midnight boot node, ensure you have the following:
 
-* [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
-* Sufficient resources (CPU, memory, and storage).
-* Either a precompiled binary or Rust toolchain (for building from source).
+- [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
+- Sufficient resources (CPU, memory, and storage).
+- Either a precompiled binary or Rust toolchain (for building from source).
 
 ## Setting Up a Boot Node
 

--- a/docs/nodes/full-node.mdx
+++ b/docs/nodes/full-node.mdx
@@ -17,30 +17,86 @@ A **Full Node** syncs with the blockchain, validates transactions, and provides 
 
 An **Archive Node** maintains the entire history of the blockchain, including all blocks and states. While this comprehensive storage consumes substantial disk space, it is essential for use cases requiring access to historical data, such as building block explorers, conducting in-depth debugging, or querying past events. Setting up an archive node involves specific configurations, such as using the --pruning archive parameter.
 
-
 ## Prerequisites
 
 Before setting up your Midnight full node, ensure you have the following:
 
-* [Docker](https://docs.docker.com/engine/install/) installed and configured.
 * [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
 * Sufficient resources (CPU, memory, and storage).
+* Either a precompiled binary or Rust toolchain (for building from source).
 
 ## Setting Up a Full Node
 
-### Step 1: Configure PostgreSQL Database
+### Option 1: Using Binary Distribution (Recommended)
 
-Set up a PostgreSQL instance with the following parameters:
+The binary distribution method is the recommended approach for most users as it requires no compilation.
 
-* **Host:** PostgreSQL server address.
-* **Port:** Default 5432.
-* *Username:** Database user.
-* **Password:** Database password.
-* **Database Name:** Name of the database (e.g., cexplorer).
+#### Step 1: Download the Binary
 
-### Step 2: Run the Docker Command for a Full Node
+Download the latest Midnight node binary from the [GitHub releases page](https://github.com/midnight-network/node/releases). Choose the binary appropriate for your operating system and architecture.
 
-Use the following Docker command to set up your full node:
+```bash
+# Example for Linux x86_64
+wget https://github.com/midnight-network/node/releases/download/v<VERSION>/midnight-node-x86_64-linux
+chmod +x midnight-node-x86_64-linux
+```
+
+Replace `<VERSION>` with the required version of the node according to the [release compatibility matrix](../../relnotes/support-matrix).
+
+#### Step 2: Run the Full Node
+
+To start a full node against a network of your choice (preview, preprod, or mainnet):
+
+```bash
+./midnight-node-x86_64-linux \
+  --chain preprod \
+  --base-path ./chain-data \
+  --rpc-max-connections 1000 \
+  --database auto
+```
+
+Or for preview network:
+
+```bash
+./midnight-node-x86_64-linux \
+  --chain preview \
+  --base-path ./chain-data \
+  --rpc-max-connections 1000 \
+  --database auto
+```
+
+### Option 2: Building from Source
+
+For users who prefer to build from source or require custom compilation:
+
+#### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/midnight-network/node.git
+cd node
+```
+
+#### Step 2: Build the Binary
+
+```bash
+cargo build --release
+```
+
+The compiled binary will be available at `target/release/midnight-node`.
+
+#### Step 3: Run the Full Node
+
+```bash
+./target/release/midnight-node \
+  --chain preview \
+  --base-path ./chain-data \
+  --rpc-max-connections 1000 \
+  --database auto
+```
+
+### Option 3: Docker (Alternative)
+
+If you prefer containerized deployment, Docker is still available as an alternative:
 
 ```bash
 docker run \
@@ -48,38 +104,42 @@ docker run \
   --platform linux/amd64 \
   -p 30333:30333 \
   -v midnight-data:/node \
-  -e MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:<VERSION>" \
   -e POSTGRES_HOST="postgres" \
   -e POSTGRES_PORT="5432" \
   -e POSTGRES_USER="postgres" \
   -e POSTGRES_PASSWORD="password123" \
   -e POSTGRES_DB="cexplorer" \
-  -e DB_SYNC_POSTGRES_CONNECTION_STRING="psql://postgres:password123@x.x.x.x:5432/cexplorer" \
   -e BASE_PATH="./node/chain/" \
-  -e CFG_PRESET="testnet-02" \
   midnightnetwork/midnight-node:<VERSION> \
-  --chain=/res/testnet-02/testnetRaw.json \
+  --chain=preview \
   --no-private-ip
 ```
 
-Replace `<VERSION>` with the required version of the node according to the [release compatibility matrix](../../relnotes/support-matrix).
-
-
 ## Setting Up an Archive Node
 
-### Step 1: Configure PostgreSQL Database
+Archive nodes require the same setup as full nodes, with the addition of the `--pruning archive` flag:
 
-Set up a PostgreSQL instance with the following parameters:
+### Using Binary
 
-* **Host:** PostgreSQL server address.
-* **Port:** Default 5432.
-* *Username:** Database user.
-* **Password:** Database password.
-* **Database Name:** Name of the database (e.g., cexplorer).
+```bash
+./midnight-node-x86_64-linux \
+  --chain preview \
+  --base-path ./chain-data \
+  --pruning archive \
+  --database auto
+```
 
-### Step 2: Run the Docker Command for an Archive Node
+### Building from Source
 
-To set up an archive node, modify the `--pruning` parameter to store all historical states:
+```bash
+./target/release/midnight-node \
+  --chain preview \
+  --base-path ./chain-data \
+  --pruning archive \
+  --database auto
+```
+
+### Using Docker
 
 ```bash
 docker run \
@@ -87,32 +147,44 @@ docker run \
   --platform linux/amd64 \
   -p 30333:30333 \
   -v midnight-data:/node \
-  -e MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:0.6.6-6288973b" \
-  -e POSTGRES_HOST="postgres" \
-  -e POSTGRES_PORT="5432" \
-  -e POSTGRES_USER="postgres" \
-  -e POSTGRES_PASSWORD="password123" \
-  -e POSTGRES_DB="cexplorer" \
-  -e DB_SYNC_POSTGRES_CONNECTION_STRING="psql://postgres:password123@x.x.x.x:5432/cexplorer" \
   -e BASE_PATH="./node/chain/" \
-  -e CFG_PRESET="testnet-02" \
-  midnightnetwork/midnight-node:0.6.6-6288973b \
-  --chain=/res/testnet-02/testnetRaw.json \
+  midnightnetwork/midnight-node:<VERSION> \
+  --chain=preview \
   --pruning archive \
   --no-private-ip
 ```
 
+## Available Networks
+
+Use one of the following values for the `--chain` parameter:
+
+* `preview` - Development preview network with frequent updates
+* `preprod` - Pre-production network for testing
+* `mainnet` - Production Midnight network
 
 ## Verifying the Node
 
 ### Check Logs
 
-Monitor the node's logs to ensure it syncs with the network:
+Monitor the node's output to ensure it syncs with the network:
 
 ```bash
+# Binary output logs to stdout
+# For Docker:
 docker logs -f <node-name>
 ```
 
 ### Test Connectivity
 
 Ensure the node's P2P port (default: `30333`) is open and reachable for network communication. Use tools like `telnet`, `netcat`, or `nmap` to verify the port status and ensure the node is properly connected to the network.
+
+### Test RPC Connectivity (Optional)
+
+If you've enabled RPC endpoints, you can test them:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "system_chain", "params": [], "id": 1}' \
+  http://127.0.0.1:9944
+```

--- a/docs/nodes/full-node.mdx
+++ b/docs/nodes/full-node.mdx
@@ -13,7 +13,7 @@ Running a full or archive node allows you to sync with the Midnight blockchain, 
 
 ## Full Node vs. Archive Node
 
-A **Full Node** syncs with the blockchain, validates transactions, and provides real-time state queries. It prunes historical states older than a configurable number (defaulting to 256 blocks), making it suitable for most dApp development and real-time interactions with the network. Its key advantage lies in its efficient use of disk space, requiring significantly less storage than an archive node. 
+A **Full Node** syncs with the blockchain, validates transactions, and provides real-time state queries. It prunes historical states older than a configurable number (defaulting to 256 blocks), making it suitable for most dApp development and real-time interactions with the network. Its key advantage lies in its efficient use of disk space, requiring significantly less storage than an archive node.
 
 An **Archive Node** maintains the entire history of the blockchain, including all blocks and states. While this comprehensive storage consumes substantial disk space, it is essential for use cases requiring access to historical data, such as building block explorers, conducting in-depth debugging, or querying past events. Setting up an archive node involves specific configurations, such as using the --pruning archive parameter.
 
@@ -21,9 +21,9 @@ An **Archive Node** maintains the entire history of the blockchain, including al
 
 Before setting up your Midnight full node, ensure you have the following:
 
-* [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
-* Sufficient resources (CPU, memory, and storage).
-* Either a precompiled binary or Rust toolchain (for building from source).
+- [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
+- Sufficient resources (CPU, memory, and storage).
+- Either a precompiled binary or Rust toolchain (for building from source).
 
 ## Setting Up a Full Node
 
@@ -158,9 +158,9 @@ docker run \
 
 Use one of the following values for the `--chain` parameter:
 
-* `preview` - Development preview network with frequent updates
-* `preprod` - Pre-production network for testing
-* `mainnet` - Production Midnight network
+- `preview` - Development preview network with frequent updates
+- `preprod` - Pre-production network for testing
+- `mainnet` - Production Midnight network
 
 ## Verifying the Node
 

--- a/docs/nodes/node-endpoints.mdx
+++ b/docs/nodes/node-endpoints.mdx
@@ -13,14 +13,25 @@ You have the option to run your own node for interacting with the Midnight netwo
 
 ## Network endpoints
 
-### Testnet network
+### Preview Network
 
 | Network | URL |
 | ------------- | ------------- |
-| Testnet-02 | https://rpc.testnet-02.midnight.network/ |
-| Explorer (temporary) | https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.testnet-02.midnight.network#/explorer |
+| Preview | https://rpc.preview.midnight.network/ |
+| WebSocket | wss://rpc.preview.midnight.network |
+| Explorer | https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.preview.midnight.network#/explorer |
 
-Example query of a Midnight node:
+### Preprod Network
+
+| Network | URL |
+| ------------- | ------------- |
+| Preprod | https://rpc.preprod.midnight.network/ |
+| WebSocket | wss://rpc.preprod.midnight.network |
+| Explorer | https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.preprod.midnight.network#/explorer |
+
+## Example Queries
+
+Query the system chain:
 
 ```bash
 curl -X POST \
@@ -31,15 +42,16 @@ curl -X POST \
         "params": [],
         "id": 1
       }' \
-  https://rpc.testnet-02.midnight.network/
+  https://rpc.preview.midnight.network/
 ```
+
 Query available RPC methods into a readable file `rpc_methods.json`:
 
 ```bash
 curl \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","method":"rpc_methods","params":[],"id":1}' \
-  https://rpc.testnet-02.midnight.network/ \
+  https://rpc.preview.midnight.network/ \
   > rpc_methods.json
 ```
 
@@ -51,7 +63,6 @@ To facilitate interaction with the Midnight Node, we have prepared an Insomnia A
 
 1. **Download the collection**
    - Click on the following link to download the Insomnia API collection file: 📦⬇ <a href="/files/Insomnia_2024-11-21.json" download>Midnight Node Insomnia Collection</a>
-.
 
 2. **Open Insomnia**
    - If you haven't already installed Insomnia, download and install it from [Insomnia's official website](https://insomnia.rest/download).

--- a/docs/nodes/node-endpoints.mdx
+++ b/docs/nodes/node-endpoints.mdx
@@ -15,19 +15,19 @@ You have the option to run your own node for interacting with the Midnight netwo
 
 ### Preview Network
 
-| Network | URL |
-| ------------- | ------------- |
-| Preview | https://rpc.preview.midnight.network/ |
-| WebSocket | wss://rpc.preview.midnight.network |
-| Explorer | https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.preview.midnight.network#/explorer |
+| Network   | URL                                                                                  |
+| --------- | ------------------------------------------------------------------------------------ |
+| Preview   | https://rpc.preview.midnight.network/                                                |
+| WebSocket | wss://rpc.preview.midnight.network                                                   |
+| Explorer  | https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.preview.midnight.network#/explorer |
 
 ### Preprod Network
 
-| Network | URL |
-| ------------- | ------------- |
-| Preprod | https://rpc.preprod.midnight.network/ |
-| WebSocket | wss://rpc.preprod.midnight.network |
-| Explorer | https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.preprod.midnight.network#/explorer |
+| Network   | URL                                                                                  |
+| --------- | ------------------------------------------------------------------------------------ |
+| Preprod   | https://rpc.preprod.midnight.network/                                                |
+| WebSocket | wss://rpc.preprod.midnight.network                                                   |
+| Explorer  | https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.preprod.midnight.network#/explorer |
 
 ## Example Queries
 

--- a/docs/nodes/rpc-node.mdx
+++ b/docs/nodes/rpc-node.mdx
@@ -19,25 +19,89 @@ An **RPC node** is a specialized type of node that exposes an HTTP or WebSocket-
 
 Before setting up your Midnight RPC node, ensure you have the following:
 
-* [Docker](https://docs.docker.com/engine/install/) installed and configured.
 * [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
 * Sufficient resources (CPU, memory, and storage).
+* Either a precompiled binary or Rust toolchain (for building from source).
 
 ## Setting Up an RPC Node
 
-### Step 1: Configure PostgreSQL Database
+### Option 1: Using Binary Distribution (Recommended)
 
-Set up a Cardano-db-sync/ PostgreSQL instance with the following parameters:
+The binary distribution method is the recommended approach for most users.
 
-* **Host:** PostgreSQL server address.
-* **Port:** Default 5432.
-* *Username:** Database user.
-* **Password:** Database password.
-* **Database Name:** Name of the database (e.g., cexplorer).
+#### Step 1: Download the Binary
 
-### Step 2: Run the Docker Command for an RPC Node
+Download the latest Midnight node binary from the [GitHub releases page](https://github.com/midnight-network/node/releases).
 
-Use the following Docker command to set up your RPC node:
+```bash
+# Example for Linux x86_64
+wget https://github.com/midnight-network/node/releases/download/v<VERSION>/midnight-node-x86_64-linux
+chmod +x midnight-node-x86_64-linux
+```
+
+Replace `<VERSION>` with the required version according to the [release compatibility matrix](../../relnotes/support-matrix).
+
+#### Step 2: Run the RPC Node
+
+To start an RPC node for the preview network:
+
+```bash
+./midnight-node-x86_64-linux \
+  --chain preview \
+  --base-path ./chain-data \
+  --rpc-methods Safe \
+  --rpc-cors all \
+  --rpc-port 9944 \
+  --rpc-external \
+  --ws-external
+```
+
+Or for the preprod network:
+
+```bash
+./midnight-node-x86_64-linux \
+  --chain preprod \
+  --base-path ./chain-data \
+  --rpc-methods Safe \
+  --rpc-cors all \
+  --rpc-port 9944 \
+  --rpc-external \
+  --ws-external
+```
+
+### Option 2: Building from Source
+
+For users who prefer to build from source:
+
+#### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/midnight-network/node.git
+cd node
+```
+
+#### Step 2: Build the Binary
+
+```bash
+cargo build --release
+```
+
+#### Step 3: Run the RPC Node
+
+```bash
+./target/release/midnight-node \
+  --chain preview \
+  --base-path ./chain-data \
+  --rpc-methods Safe \
+  --rpc-cors all \
+  --rpc-port 9944 \
+  --rpc-external \
+  --ws-external
+```
+
+### Option 3: Docker (Alternative)
+
+If you prefer containerized deployment:
 
 ```bash
 docker run \
@@ -46,44 +110,55 @@ docker run \
   -p 9944:9944 \
   -p 30333:30333 \
   -v midnight-data:/node \
-  -e MIDNIGHT_NODE_IMAGE="midnightnetwork/midnight-node:<VERSION>" \
   -e BASE_PATH="./node/chain/" \
-  -e CFG_PRESET="testnet-02" \
   midnightnetwork/midnight-node:<VERSION> \
-  --chain=/res/testnet-02/testnetRaw.json \
+  --chain=preview \
   --rpc-methods=Safe \
   --rpc-cors=all \
   --rpc-external \
   --ws-external
 ```
 
-Replace `<VERSION>` with the required version of the node according to the [release compatibility matrix](../../relnotes/support-matrix).
+## Available Networks
 
+Use one of the following values for the `--chain` parameter:
+
+* `preview` - Development preview network with frequent updates
+* `preprod` - Pre-production network for testing
+* `mainnet` - Production Midnight network
 
 ## Verifying the Node
 
 ### Check Logs
 
-Monitor the node's logs to ensure it syncs with the network:
+Monitor the node's output to ensure it syncs with the network:
 
 ```bash
+# Binary output logs to stdout
+# For Docker:
 docker logs -f <node-name>
 ```
 
-### Test Connectivity
+### Test P2P Connectivity
 
 Ensure the node's P2P port (default: `30333`) is open and reachable for network communication. Use tools like `telnet`, `netcat`, or `nmap` to verify the port status and ensure the node is properly connected to the network.
 
-Additionally, to preview the available RPC methods, run the following curl command, which lists all endpoints exposed by the node:
+### Test RPC Connectivity
+
+To preview the available RPC methods, run the following curl command:
 
 ```bash
-curl -H "Content-Type: application/json" \
-     -X POST \
-     -d '{
-           "jsonrpc":"2.0",
-           "id":1,
-           "method":"rpc_methods",
-           "params":[]
-         }' \
-     http://127.0.0.1:9944
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"rpc_methods","params":[],"id":1}' \
+  http://127.0.0.1:9944
+```
+
+Test a basic RPC call:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"system_chain","params":[],"id":1}' \
+  http://127.0.0.1:9944
 ```

--- a/docs/nodes/rpc-node.mdx
+++ b/docs/nodes/rpc-node.mdx
@@ -19,9 +19,9 @@ An **RPC node** is a specialized type of node that exposes an HTTP or WebSocket-
 
 Before setting up your Midnight RPC node, ensure you have the following:
 
-* [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
-* Sufficient resources (CPU, memory, and storage).
-* Either a precompiled binary or Rust toolchain (for building from source).
+- [Cardano-db-sync instance set up](./cardano-db-sync) with accessible PostgreSQL port.
+- Sufficient resources (CPU, memory, and storage).
+- Either a precompiled binary or Rust toolchain (for building from source).
 
 ## Setting Up an RPC Node
 
@@ -123,9 +123,9 @@ docker run \
 
 Use one of the following values for the `--chain` parameter:
 
-* `preview` - Development preview network with frequent updates
-* `preprod` - Pre-production network for testing
-* `mainnet` - Production Midnight network
+- `preview` - Development preview network with frequent updates
+- `preprod` - Pre-production network for testing
+- `mainnet` - Production Midnight network
 
 ## Verifying the Node
 


### PR DESCRIPTION


## Description

Updates Node section per issue #665:

- Added binary distribution method (primary)
- Added source compilation method (alternative)
- Removed testnet-02 references
- Updated to preview, preprod, mainnet networks
- Updated RPC endpoints
- Updated boot node addresses
- Updated validator Ogmios endpoints

## Files Changed
- docs/nodes/full-node.mdx
- docs/nodes/boot-node.mdx
- docs/nodes/rpc-node.mdx
- docs/nodes/node-endpoints.mdx
- docs/nodes/_run-a-validator/step-1.mdx
- docs/nodes/_run-a-validator/index.mdx

