### PR TITLE
Correct Dust address prefix to match implementation

### DIFF
--- a/sdks/official/wallet-dev-guide.mdx
+++ b/sdks/official/wallet-dev-guide.mdx
@@ -341,7 +341,7 @@ Midnight supports three address types:
 |--------|------|-------------|
 | `mn_addr` | Unshielded | Payment addresses for NIGHT and unshielded tokens |
 | `mn_shield-addr` | Shielded | Payment addresses for shielded tokens |
-| `mn_dust-addr` | DUST | Addresses for DUST generation |
+| `mn_dust` | DUST | Addresses for DUST generation |
 
 Each prefix includes a network identifier:
 - **Mainnet**: no suffix (for example, `mn_addr`)


### PR DESCRIPTION
Due to a mistake, the Dust addresses used in practice have prefix `mn_dust` instead of `mn_dust-addr`. This PR corrects the documentation to match the implementations