### PR TITLE
Fix typo in Lace wallet configuration instructions

### DIFF
--- a/docs/guides/midnight-local-network.mdx
+++ b/docs/guides/midnight-local-network.mdx
@@ -245,7 +245,7 @@ Operation failed: Expected undeployed address, got Preprod address
 
 It means you're trying to fund a wallet with a Preprod address. You need to use the Undeployed network address instead.
 
-If you're using the Lace wallet, thenyou need to configure the wallet to use the Undeployed network. 
+If you're using the Lace wallet, then you need to configure the wallet to use the Undeployed network. 
 
 1. In the Lace wallet extension, navigate to the **Settings** page and click **Midnight** under the Wallet section. 
 2. Select the **Undeployed** network and click **Save configuration**.


### PR DESCRIPTION
This pull request changes "thenyou" to "then you" in the "lnvalid wallet address" section of the [midnight local network page](https://docs.midnight.network/guides/midnight-local-network)

