### PR TITLE
Add troubleshooting page for decoding 1010 transaction errors

### DIFF
--- a/docs/troubleshoot/decode-1010-transaction-rejection-errors.mdx
+++ b/docs/troubleshoot/decode-1010-transaction-rejection-errors.mdx
@@ -57,7 +57,7 @@ try {
 ```
 
 </TabItem>
-<TabItem value="curl" label="curl">
+<TabItem value="curl" label="cURL">
 
 ```bash
 curl -H "Content-Type: application/json" \
@@ -420,5 +420,5 @@ A successful submission returns a transaction hash rather than an error envelope
 
 If you cannot identify the variant or the rejection persists after applying the fixes above:
 
-1. **Confirm the node version**: variant numbering changes across releases. Check the [node release notes](../relnotes/node.mdx) for the version your network is running.
-2. **Check the compatibility matrix**: verify the proof server, runtime, and SDK match the supported set in the [release compatibility matrix](../relnotes/support-matrix.mdx).
+- **Confirm the node version**: Variant numbering changes across releases. Check the [node release notes](../relnotes/node.mdx) for the version your network is running.
+- **Check the compatibility matrix**: Verify the proof server, runtime, and SDK match the supported set in the [release compatibility matrix](../relnotes/support-matrix.mdx).

--- a/docs/troubleshoot/decode-1010-transaction-rejection-errors.mdx
+++ b/docs/troubleshoot/decode-1010-transaction-rejection-errors.mdx
@@ -1,0 +1,424 @@
+---
+title: Decode 1010 transaction rejection errors
+description: Decode the inner u8 in Substrate code 1010 "Invalid Transaction" responses to identify the underlying Midnight ledger error variant.
+sidebar_label: Decode 1010 errors
+sidebar_position: 30
+tags: [troubleshooting, errors, transactions, rpc]
+slug: /how-to/decode-1010-transaction-rejection-errors
+---
+
+import Step, { StepsProvider } from "@site/src/components/Step/Step";
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
+
+# Decode 1010 transaction rejection errors
+
+Resolve `1010 Invalid Transaction` responses by decoding the inner `Custom error: N` value into a Midnight ledger error variant.
+
+## Understand the cause of the error
+
+When you submit a transaction to a Midnight node, the JSON-RPC layer may reject it with code `1010`:
+
+```json
+{
+  "code": 1010,
+  "message": "Invalid Transaction",
+  "data": "Custom error: 155"
+}
+```
+
+Code `1010` itself is a [Substrate](https://github.com/paritytech/polkadot-sdk/tree/master/substrate) envelope, not a Midnight-specific error. It signals that the node's transaction pool rejected the extrinsic. The actionable signal is the `N` in `Custom error: N`, which is a `u8` (0–255) corresponding to a `LedgerApiError` variant defined by the Midnight node.
+
+:::info Two layers, one error
+The `1010` is inherited from Substrate. The inner `u8` is Midnight's. To diagnose the problem, you must decode the `u8`.
+:::
+
+## Extract the inner u8
+
+The inner `u8` is embedded in the `data` field of the RPC error response. Use the steps below to extract it from common client environments.
+
+<StepsProvider>
+
+<Step>
+
+### Capture the full RPC response
+
+Capture the complete error response, not just the message string. Many wallet libraries and CLI wrappers truncate the `data` field by default.
+
+<Tabs>
+<TabItem value="js" label="JavaScript">
+
+```javascript
+try {
+  await api.tx.someCall().signAndSend(account);
+} catch (err) {
+  console.error(JSON.stringify(err, null, 2));
+}
+```
+
+</TabItem>
+<TabItem value="curl" label="curl">
+
+```bash
+curl -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"author_submitExtrinsic","params":["0x..."]}' \
+  http://localhost:9944
+```
+
+</TabItem>
+</Tabs>
+
+</Step>
+
+<Step>
+
+### Read the trailing integer in the data field
+
+The `data` field ends with `Custom error: N` where `N` is the variant code:
+
+```text
+"data": "Custom error: 155"
+```
+
+In this example, `N` is `155`.
+
+</Step>
+
+<Step>
+
+### Look up the variant
+
+Use the [variant tables](#look-up-the-variant) below to map the `u8` to its ledger error name and category.
+
+</Step>
+
+</StepsProvider>
+
+:::caution Variant codes change between releases
+Variant numbering is defined by the Midnight node and may change across releases. For example, `168 FeeCalculation` was retired and replaced by `155 FeeCalculationError`. Always cross-reference the variant against the [release notes](../relnotes/node.mdx) for the node version your network is running.
+:::
+
+## Look up the variant
+
+The tables below list every `LedgerApiError` variant currently emitted by the Midnight node, grouped by category. Each row shows the `u8`, the variant name, and the meaning. Use the `Custom error: N` value extracted in the previous step to find the corresponding row.
+
+### Deserialization errors (0–11)
+
+The node could not decode an input from its serialized form. The transaction is rejected before any ledger logic runs.
+
+<details>
+<summary><strong>Show full table</strong></summary>
+
+| Code | Variant |
+| ---- | ------- |
+| 0    | NetworkId |
+| 1    | Transaction |
+| 2    | LedgerState |
+| 3    | ContractAddress |
+| 4    | PublicKey |
+| 5    | VersionedArenaKey |
+| 6    | UserAddress |
+| 7    | TypedArenaKey |
+| 8    | SystemTransaction |
+| 9    | DustPublicKey |
+| 10   | CNightGeneratesDustActionType |
+| 11   | CNightGeneratesDustEvent |
+
+</details>
+
+### Serialization errors (50–63)
+
+The node could not encode a value to its serialized form. These typically indicate an internal inconsistency rather than a client error.
+
+<details>
+<summary><strong>Show full table</strong></summary>
+
+| Code | Variant |
+| ---- | ------- |
+| 50   | TransactionIdentifier |
+| 51   | LedgerState |
+| 52   | LedgerParameters |
+| 53   | ContractAddress |
+| 54   | ContractState |
+| 55   | ContractStateToJson |
+| 56   | ZswapState |
+| 57   | UnknownType |
+| 58   | MerkleTreeDigest |
+| 59   | VersionedArenaKey |
+| 60   | TypedArenaKey |
+| 61   | CNightGeneratesDustEvent |
+| 62   | SystemTransaction |
+| 63   | ArenaHash |
+
+</details>
+
+### Invalid transactions (100–109, 193–200, 239–250)
+
+The transaction is structurally valid but conflicts with current ledger state. These are the most common rejections in production traffic.
+
+<details>
+<summary><strong>Show full table</strong></summary>
+
+| Code | Variant |
+| ---- | ------- |
+| 100  | EffectsMismatch |
+| 101  | ContractAlreadyDeployed |
+| 102  | ContractNotPresent |
+| 103  | Zswap |
+| 104  | Transcript |
+| 105  | InsufficientClaimable |
+| 106  | VerifierKeyNotFound |
+| 107  | VerifierKeyAlreadyPresent |
+| 108  | ReplayCounterMismatch |
+| 109  | UnknownError |
+| ~~193~~ | ~~ReplayProtectionViolation~~ _(Retired)_ |
+| 194  | BalanceCheckOutOfBounds |
+| 195  | InputNotInUtxos |
+| 196  | DustDoubleSpend |
+| 197  | DustDeregistrationNotRegistered |
+| 198  | GenerationInfoAlreadyPresent |
+| 199  | InvariantViolation |
+| 200  | RewardTooSmall |
+| 239  | Zswap.Invalid.NullifierAlreadyPresent |
+| 240  | Zswap.Invalid.CommitmentAlreadyPresent |
+| 241  | Zswap.Invalid.UnknownMerkleRoot |
+| 242  | ReplayProtectionViolation.IntentTtlExpired |
+| 243  | ReplayProtectionViolation.IntentTtlTooFarInFuture |
+| 244  | ReplayProtectionViolation.IntentAlreadyExists |
+| 248  | DivideByZero |
+| 249  | Invalid.MerkleTreeError |
+| 250  | Zswap.Invalid.MerkleTreeError |
+
+</details>
+
+### Malformed transactions (110–139, 166–192, 212–238)
+
+The transaction failed structural or cryptographic validation. The submitting client should treat these as bugs in transaction construction or signing.
+
+<details>
+<summary><strong>Show full table</strong></summary>
+
+| Code | Variant |
+| ---- | ------- |
+| 110  | VerifierKeyNotSet |
+| 111  | TransactionTooLarge |
+| 112  | VerifierKeyTooLarge |
+| 113  | VerifierKeyNotPresent |
+| 114  | ContractNotPresent |
+| 115  | InvalidProof |
+| 116  | BindingCommitmentOpeningInvalid |
+| 117  | NotNormalized |
+| 118  | FallibleWithoutCheckpoint |
+| 119  | ClaimReceiveFailed |
+| 120  | ClaimSpendFailed |
+| 121  | ClaimNullifierFailed |
+| 122  | ClaimCallFailed |
+| 123  | InvalidSchnorrProof |
+| 124  | UnclaimedCoinCom |
+| 125  | UnclaimedNullifier |
+| 126  | Unbalanced |
+| 127  | Zswap |
+| 128  | BuiltinDecode |
+| 129  | GuaranteedLimit |
+| 130  | MergingContracts |
+| 131  | CantMergeTypes |
+| 132  | ClaimOverflow |
+| 133  | ClaimCoinMismatch |
+| 134  | KeyNotInCommittee |
+| 135  | InvalidCommitteeSignature |
+| 136  | ThresholdMissed |
+| 137  | TooManyZswapEntries |
+| 138  | BalanceCheckOverspend |
+| 139  | UnknownError |
+| 166  | InvalidNetworkId |
+| 167  | IllegallyDeclaredGuaranteed |
+| ~~168~~ | ~~FeeCalculation~~ _(Retired)_ |
+| 169  | InvalidDustRegistrationSignature |
+| 170  | InvalidDustSpendProof |
+| 171  | OutOfDustValidityWindow |
+| 172  | MultipleDustRegistrationsForKey |
+| 173  | InsufficientDustForRegistrationFee |
+| 174  | MalformedContractDeploy |
+| 175  | IntentSignatureVerificationFailure |
+| 176  | IntentSignatureKeyMismatch |
+| 177  | IntentSegmentIdCollision |
+| 178  | IntentAtGuaranteedSegmentId |
+| 179  | UnsupportedProofVersion |
+| 180  | GuaranteedTranscriptVersion |
+| 181  | FallibleTranscriptVersion |
+| ~~182~~ | ~~TransactionApplicationError~~ _(Retired)_ |
+| 183  | BalanceCheckOutOfBounds |
+| 184  | BalanceCheckConversionFailure |
+| 185  | PedersenCheckFailure |
+| ~~186~~ | ~~EffectsCheckFailure~~ _(Retired)_ |
+| ~~187~~ | ~~DisjointCheckFailure~~ _(Retired)_ |
+| ~~188~~ | ~~SequencingCheckFailure~~ _(Retired)_ |
+| 189  | InputsNotSorted |
+| 190  | OutputsNotSorted |
+| 191  | DuplicateInputs |
+| 192  | InputsSignaturesLengthMismatch |
+| 212  | EffectsCheck.RealCallsSubsetCheckFailure |
+| 213  | EffectsCheck.AllCommitmentsSubsetCheckFailure |
+| 214  | EffectsCheck.RealUnshieldedSpendsSubsetCheckFailure |
+| 215  | EffectsCheck.ClaimedUnshieldedSpendsUniquenessFailure |
+| 216  | EffectsCheck.ClaimedCallsUniquenessFailure |
+| 217  | EffectsCheck.NullifiersNeqClaimedNullifiers |
+| 218  | EffectsCheck.CommitmentsNeqClaimedShieldedReceives |
+| 219  | SequencingCheck.CallSequencingViolation |
+| 220  | SequencingCheck.SequencingCorrelationViolation |
+| 221  | SequencingCheck.GuaranteedInFallibleContextViolation |
+| 222  | SequencingCheck.FallibleInGuaranteedContextViolation |
+| 223  | SequencingCheck.CausalityConstraintViolation |
+| 224  | SequencingCheck.CallHasEmptyTranscripts |
+| 225  | DisjointCheck.ShieldedInputsDisjointFailure |
+| 226  | DisjointCheck.ShieldedOutputsDisjointFailure |
+| 227  | DisjointCheck.UnshieldedInputsDisjointFailure |
+| 228  | TransactionApplication.IntentTtlExpired |
+| 229  | TransactionApplication.IntentTtlTooFarInFuture |
+| 230  | TransactionApplication.IntentAlreadyExists |
+| 231  | FeeCalculation.OutsideTimeToDismiss |
+| 232  | FeeCalculation.BlockLimitExceeded |
+| 233  | MalformedContractDeploy.NonZeroBalance |
+| 234  | MalformedContractDeploy.IncorrectChargedState |
+| 235  | Zswap.Malformed.InvalidProof |
+| 236  | Zswap.Malformed.ContractSentCiphertext |
+| 237  | Zswap.Malformed.NonDisjointCoinMerge |
+| 238  | Zswap.Malformed.NotNormalized |
+
+</details>
+
+### Infrastructure errors (150–157, 165)
+
+The node could not complete an internal operation, such as a ledger lookup or fee calculation. These are not caused by the submitted transaction.
+
+<details>
+<summary><strong>Show full table</strong></summary>
+
+| Code | Variant |
+| ---- | ------- |
+| 150  | LedgerCacheError |
+| 151  | NoLedgerState |
+| 152  | LedgerStateScaleDecodingError |
+| 153  | ContractCallCostError |
+| 154  | BlockLimitExceededError |
+| 155  | FeeCalculationError |
+| 156  | ContractNotPresent |
+| 157  | BeneficiaryNotFound |
+| 165  | GetTransactionContextError |
+
+</details>
+
+### System transactions (201–211, 245–247)
+
+The node rejected a system-level transaction such as a payout or treasury operation. These are typically only seen by validators or block producers.
+
+<details>
+<summary><strong>Show full table</strong></summary>
+
+| Code | Variant |
+| ---- | ------- |
+| 201  | IllegalPayout |
+| 202  | InsufficientTreasuryFunds |
+| 203  | CommitmentAlreadyPresent |
+| 204  | UnknownError |
+| ~~205~~ | ~~ReplayProtectionFailure~~ _(Retired)_ |
+| 206  | IllegalReserveDistribution |
+| 207  | GenerationInfoAlreadyPresent |
+| 208  | InvalidBasisPoints |
+| 209  | InvariantViolation |
+| 210  | TreasuryDisabled |
+| 211  | MerkleTreeError |
+| 245  | SystemTransaction.ReplayProtectionFailure.IntentTtlExpired |
+| 246  | SystemTransaction.ReplayProtectionFailure.IntentTtlTooFarInFuture |
+| 247  | SystemTransaction.ReplayProtectionFailure.IntentAlreadyExists |
+
+</details>
+
+### Host API error (255)
+
+A reserved variant indicating that the node's host API surfaced an error not covered by the categories above.
+
+<details>
+<summary><strong>Show full table</strong></summary>
+
+| Code | Variant |
+| ---- | ------- |
+| 255  | HostApiError |
+
+</details>
+
+## Common causes and fixes
+
+The following variants account for the majority of `1010` errors.
+
+<details>
+<summary><strong>155 FeeCalculationError</strong> — fee calculation failed for the submitted transaction</summary>
+
+Most often caused by stale fee estimates or an outdated runtime client. Refresh the client's view of network fees and resubmit. If the error persists, verify that your runtime packages match the values in the [release compatibility matrix](../relnotes/support-matrix.mdx).
+
+</details>
+
+<details>
+<summary><strong>154 BlockLimitExceededError</strong> — the transaction would exceed the block resource limits</summary>
+
+Reduce the number of intents, calls, or similar in the transaction. For batched operations, split the work across multiple transactions.
+
+</details>
+
+<details>
+<summary><strong>108 ReplayCounterMismatch / 193 ReplayProtectionViolation</strong> — replay protection rejected the transaction</summary>
+
+Either the replay counter is stale or the intent's TTL window has elapsed. Re-fetch the current counter and rebuild the transaction. Variants `242`–`244` and `228`–`230` give finer-grained reasons (TTL expired, TTL too far in the future, intent already exists).
+
+</details>
+
+<details>
+<summary><strong>115 InvalidProof / 235 Zswap.Malformed.InvalidProof</strong> — a zero-knowledge proof failed verification</summary>
+
+Confirm that the proof server is running a version compatible with the node and SDK. See [run a proof server](../guides/run-proof-server.mdx) and the [release compatibility matrix](../relnotes/support-matrix.mdx).
+
+</details>
+
+<details>
+<summary><strong>166 InvalidNetworkId</strong> — the transaction was constructed for a different network</summary>
+
+Verify that the SDK and wallet are configured for the same network ID as the node you are submitting to (for example, `Preprod` vs `TestNet02`).
+
+</details>
+
+<details>
+<summary><strong>126 Unbalanced / 138 BalanceCheckOverspend</strong> — the transaction's inputs and outputs do not balance</summary>
+
+The wallet attempted to spend more than the available coin set permits, or change outputs were miscalculated. Re-sync the wallet and rebuild the transaction.
+
+</details>
+
+## When 1010 has no inner u8
+
+If the response contains `code: 1010` but no `Custom error: N` substring, the rejection happened in upstream Substrate validation rather than Midnight ledger logic. The most common causes are:
+
+- **Bad signature**: the signing key does not match the sender, or the payload was altered after signing.
+- **Stale era**: the mortal era window has passed. Re-fetch the current block hash and rebuild the transaction.
+- **Wrong nonce**: the account nonce on the node does not match the value used when signing. Query the current nonce and resubmit.
+
+These rejections are not represented in the `LedgerApiError` tables because they never reach the ledger.
+
+## Verify the fix
+
+After identifying and addressing the variant, resubmit the transaction and confirm it is accepted:
+
+```bash
+# Re-submit and observe the response
+curl -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"author_submitExtrinsic","params":["0x..."]}' \
+  http://localhost:9944
+```
+
+A successful submission returns a transaction hash rather than an error envelope.
+
+## Get help
+
+If you cannot identify the variant or the rejection persists after applying the fixes above:
+
+1. **Confirm the node version**: variant numbering changes across releases. Check the [node release notes](../relnotes/node.mdx) for the version your network is running.
+2. **Check the compatibility matrix**: verify the proof server, runtime, and SDK match the supported set in the [release compatibility matrix](../relnotes/support-matrix.mdx).


### PR DESCRIPTION
Adds a how-to page explaining the Substrate `1010 Invalid Transaction` envelope and mapping the inner `Custom error: N` u8 to the corresponding Midnight `LedgerApiError` variant. Closes the structural observability gap reported on v8 Preprod where developers had no path to decode the inner u8 back to a ledger error.