### PR TITLE
docs: update proof-server version in bboard and counter examples

### DIFF
--- a/docs/examples/dapps/bboard.mdx
+++ b/docs/examples/dapps/bboard.mdx
@@ -166,7 +166,7 @@ The proof server generates ZK proofs for transactions locally to protect private
 Start the proof server:
 
 ```bash
-docker run -p 6300:6300 midnightntwrk/proof-server:7.0.0 -- midnight-proof-server -v
+docker run -p 6300:6300 midnightntwrk/proof-server:8.0.3 -- midnight-proof-server -v
 ```
 
 :::tip

--- a/docs/examples/dapps/counter.mdx
+++ b/docs/examples/dapps/counter.mdx
@@ -116,7 +116,7 @@ The proof server generates Zero Knowledge (ZK) proofs for transactions locally t
 Start the proof server for Preprod:
 
 ```bash
-docker run -p 6300:6300 midnightntwrk/proof-server:7.0.0 -- midnight-proof-server -v
+docker run -p 6300:6300 midnightntwrk/proof-server:8.0.3 -- midnight-proof-server -v
 ```
 
 You should see output similar to:


### PR DESCRIPTION
## Summary

Updates the proof-server Docker image tag from `7.0.0` to `8.0.3` in the Bulletin Board and Counter DApp example pages.

## Changes

- `docs/examples/dapps/bboard.mdx` line 169
- `docs/examples/dapps/counter.mdx` line 119

```diff
- docker run -p 6300:6300 midnightntwrk/proof-server:7.0.0 -- midnight-proof-server -v
+ docker run -p 6300:6300 midnightntwrk/proof-server:8.0.3 -- midnight-proof-server -v
```

## Related

- Closes #904