### PR TITLE
fix: correct circuit name typo in explicit-disclosure.mdx

### DIFF
--- a/docs/compact/reference/explicit-disclosure.mdx
+++ b/docs/compact/reference/explicit-disclosure.mdx
@@ -24,7 +24,7 @@ import CompactStandardLibrary;
 witness getBalance(): Bytes<32>;
 export ledger balance: Bytes<32>;
 
-export circuit recordRalance(): [] {
+export circuit recordBalance(): [] {
   balance = disclose(getBalance());
 }
 ```


### PR DESCRIPTION
## Summary

Fixes a typo in the explicit disclosure reference page where a code example
used the misspelled circuit name `recordRalance` instead of `recordBalance`.

## Changes

- `docs/compact/reference/explicit-disclosure.mdx`: renamed `recordRalance` → `recordBalance`

## Why this matters

The first code block on the page intentionally shows a *working* example of
`disclose()` usage, but the misspelled name is inconsistent with the corrected
example shown directly below it. A developer following along or copy-pasting
the snippet would get unexpected behaviour from their TypeScript API since the
generated function name would be wrong.