### PR TITLE
fix: standardize pragma language_version from 0.21 to 0.22 across tutorials and examples

### DIFF
--- a/docs/examples/dapps/bboard.mdx
+++ b/docs/examples/dapps/bboard.mdx
@@ -55,7 +55,7 @@ application where users can prove ownership of posted content without revealing 
 Here is the complete contract:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 

--- a/docs/examples/dapps/counter.mdx
+++ b/docs/examples/dapps/counter.mdx
@@ -44,7 +44,7 @@ The Counter contract is written in Compact and includes the following components
 Here's the complete contract:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -83,7 +83,7 @@ my-app/
 The `contracts/hello-world.compact` file contains the Compact smart contract code.
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 export ledger message: Opaque<"string">;
 

--- a/docs/guides/install-bun-runtime-midnight.mdx
+++ b/docs/guides/install-bun-runtime-midnight.mdx
@@ -280,7 +280,7 @@ touch contracts/message.compact
 2. Add the code below to the file:
 
 ```compact title="message.compact"
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 
@@ -297,8 +297,8 @@ export circuit storeMessage(customMessage: Opaque<"string">): [] {
 
 Explanation:
 
-- `pragma language_version 0.21;`
-  Specifies the exact Compact compiler version required for this smart contract. Using version 0.18 ensures compatibility with the runtime version 0.9.0 you installed earlier.
+- `pragma language_version 0.22;`
+  Specifies the exact Compact compiler version required for this smart contract. Using version 0.22 ensures compatibility with the current Midnight runtime.
 - `import CompactStandardLibrary;`
   Loads standard functions and types provided by Midnight for contracts.
 - `export ledger message: Opaque<"string">;`
@@ -571,7 +571,7 @@ Solution:
 Update your smart contract to use the exact language version:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 ```
 
 :::note

--- a/docs/tutorials/bboard/smart-contract.mdx
+++ b/docs/tutorials/bboard/smart-contract.mdx
@@ -61,7 +61,7 @@ Open this file in your code editor.
 The `pragma language_version` directive specifies which version of Compact your contract uses:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 ```
 
 This directive:
@@ -75,7 +75,7 @@ This directive:
 Import Compact's standard library for built-in types and functions:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 ```
@@ -91,7 +91,7 @@ To learn more about what's available in the standard library, see the [Compact s
 The bulletin board has two possible states. Define an enumeration type to represent them:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 
@@ -113,7 +113,7 @@ This enumeration:
 The ledger represents the public, on-chain state of your contract. For the bulletin board, you need four pieces of public information:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 
@@ -280,7 +280,7 @@ The domain separator is a security best practice. It ensures that hashes generat
 Your complete bulletin board contract should now look like this:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 

--- a/docs/tutorials/counter/smart-contract.mdx
+++ b/docs/tutorials/counter/smart-contract.mdx
@@ -145,7 +145,7 @@ Open this file in your code editor.
 The `pragma language_version` directive specifies which version of Compact your contract uses:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 ```
 
 This directive:
@@ -159,7 +159,7 @@ This directive:
 Import Compact's standard library for built-in types and functions:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 ```
@@ -173,7 +173,7 @@ The ledger represents the public, on-chain state of your contract.
 Add the ledger declaration:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 
@@ -195,7 +195,7 @@ Circuits are the entry points to your smart contract. They define the logic that
 Add the `increment` circuit definition:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 
@@ -218,7 +218,7 @@ This circuit defines the contract's only operation:
 Your complete counter contract should now look like this:
 
 ```compact
-pragma language_version 0.21;
+pragma language_version 0.22;
 
 import CompactStandardLibrary;
 


### PR DESCRIPTION
## Summary

Several tutorials and example pages still used `pragma language_version 0.21;`
while the newer docs (hello-world, compact/writing.mdx, and contract examples)
already use `0.22`. This standardizes all Compact code samples to version 0.22.

## Changes (17 occurrences across 6 files)

- `docs/tutorials/bboard/smart-contract.mdx` — 5 instances
- `docs/tutorials/counter/smart-contract.mdx` — 5 instances
- `docs/getting-started/quickstart.mdx` — 1 instance
- `docs/guides/install-bun-runtime-midnight.mdx` — 3 instances + fixed a
  stale inline comment that referenced version 0.18
- `docs/examples/dapps/bboard.mdx` — 1 instance
- `docs/examples/dapps/counter.mdx` — 1 instance

## Why this matters

A developer copying contract code from a tutorial and compiling it against a
current Compact compiler that targets 0.22 may get warnings or errors due to
the version mismatch. Consistent version usage across all docs also prevents
confusion about which version is current.