### PR TITLE
Add midnight-js v4.1.1 release notes

### DIFF
--- a/docs/relnotes/midnight-js/midnight-js-4-1-1.mdx
+++ b/docs/relnotes/midnight-js/midnight-js-4-1-1.mdx
@@ -1,0 +1,77 @@
+
+
+### ⚠ BREAKING CHANGES
+
+* **midnight-js:** IndexerFormattedError.cause is renamed to .errors.
+
+The ES2022 Error.cause slot is contractually a single underlying error,
+not a peer collection of GraphQL errors. Shadowing it broke Node's
+util.inspect causal chain, Sentry grouping, and structured loggers.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+* refactor(midnight-js): extract correlateDeployTxId for cast-free tests
+
+Pulls the contract-action / identifier correlation into a small pure
+helper that takes narrow structural types. Eliminates the
+'as unknown as RegularTransaction' fixture cast that violated the
+project rule, and shrinks the public API: toFinalizedDeployTxData is
+now a file-local const, with only the focused helper exported for tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+* refactor(midnight-js): replace non-null assertions on contractAction with type predicate
+
+Lines 410 and 449 used Rx.filter + ! assertions to satisfy the type
+
+### Features
+
+* **testkit-js:** parameterize compose image versions + nightly e2e matrix ([#917](https://github.com/midnightntwrk/midnight-js/pull/917)) ([1621524](https://github.com/midnightntwrk/midnight-js/commit/16215240e02f738374aa644c43039ae5c90f962f))
+* **testkit-js:** support qanet via NIGHT/dust faucet flow ([73a3fd5](https://github.com/midnightntwrk/midnight-js/commit/73a3fd59a549ff09940ab85f5ad3995288b5063a))
+
+
+### Bug Fixes
+
+* **midnight-js:** apply full password policy to export operations ([#922](https://github.com/midnightntwrk/midnight-js/pull/922)) ([c6f43dd](https://github.com/midnightntwrk/midnight-js/commit/c6f43dda1f5f1cf7cc124baa37f7417fe919ef1d)), closes [#819](https://github.com/midnightntwrk/midnight-js/pull/819)
+* **midnight-js:** emit contract state for blockHeight/blockHash configs ([#911](https://github.com/midnightntwrk/midnight-js/pull/911)) ([f8d2e48](https://github.com/midnightntwrk/midnight-js/commit/f8d2e48ba026f21597f9a634b4b87874dc0b7bec)), closes [#805](https://github.com/midnightntwrk/midnight-js/pull/805)
+* **midnight-js:** harden error handling in indexer-public-data-provider ([#937](https://github.com/midnightntwrk/midnight-js/pull/937)) ([28c840a](https://github.com/midnightntwrk/midnight-js/commit/28c840a33efbdc6f3b93756d981baeb82382251c)), closes [#823](https://github.com/midnightntwrk/midnight-js/pull/823) [#822](https://github.com/midnightntwrk/midnight-js/pull/822) [#821](https://github.com/midnightntwrk/midnight-js/pull/821) [#821](https://github.com/midnightntwrk/midnight-js/pull/821)
+* **midnight-js:** validate signing key value on import ([#926](https://github.com/midnightntwrk/midnight-js/pull/926)) ([9fa41f4](https://github.com/midnightntwrk/midnight-js/commit/9fa41f43a63031a1f04e325818762c9413cb6790)), closes [#824](https://github.com/midnightntwrk/midnight-js/pull/824)
+* **midnight-js:** warn on plain http/ws for non-loopback provider URLs ([#920](https://github.com/midnightntwrk/midnight-js/pull/920)) ([dc6a3c6](https://github.com/midnightntwrk/midnight-js/commit/dc6a3c6360cca87d51a62b563863f403439e99c9)), closes [#818](https://github.com/midnightntwrk/midnight-js/pull/818)
+* **testkit-js:** derive waitForFunds address from keystore ([f1b980b](https://github.com/midnightntwrk/midnight-js/commit/f1b980b51962a924e28d11ca1c27dc0054bc6584))
+
+
+### Documentation
+
+* API documentation update ([#910](https://github.com/midnightntwrk/midnight-js/pull/910)) ([96146e5](https://github.com/midnightntwrk/midnight-js/commit/96146e53107417d5361133d6e342d92eb1b3e45f))
+* API documentation update ([#924](https://github.com/midnightntwrk/midnight-js/pull/924)) ([092257c](https://github.com/midnightntwrk/midnight-js/commit/092257cb9bc4210de2171c1ed3aba08543ad6e1c))
+* API documentation update ([#934](https://github.com/midnightntwrk/midnight-js/pull/934)) ([7370b65](https://github.com/midnightntwrk/midnight-js/commit/7370b6506dcab281df61233bd104babb825133db))
+* API documentation update ([#939](https://github.com/midnightntwrk/midnight-js/pull/939)) ([5251bce](https://github.com/midnightntwrk/midnight-js/commit/5251bce03e0825f42848d735583635356e9b2ebd))
+* **midnight-js:** clarify provider semantics and tx privacy ([#918](https://github.com/midnightntwrk/midnight-js/pull/918)) ([cc9312e](https://github.com/midnightntwrk/midnight-js/commit/cc9312e4f7081db13db5193a12e121b96b11c03b)), closes [#870](https://github.com/midnightntwrk/midnight-js/pull/870) [#871](https://github.com/midnightntwrk/midnight-js/pull/871) [#872](https://github.com/midnightntwrk/midnight-js/pull/872)
+
+
+### Code Refactoring
+
+* co-locate contracts governance code under src/governance/ ([#909](https://github.com/midnightntwrk/midnight-js/pull/909)) ([0199119](https://github.com/midnightntwrk/midnight-js/commit/01991194c589257e762c75c0a01b029a164babf8))
+
+
+### Tests
+
+* **testkit-js-e2e:** add regression test for shielded segment routing ([#876](https://github.com/midnightntwrk/midnight-js/pull/876)) ([#903](https://github.com/midnightntwrk/midnight-js/pull/903)) ([3e93cc5](https://github.com/midnightntwrk/midnight-js/commit/3e93cc588f9b6775f79f4d78ac3c668e6cec0376))
+
+
+### Continuous Integration
+
+* bump pinned GitHub Actions to latest versions ([#927](https://github.com/midnightntwrk/midnight-js/pull/927)) ([150ecd4](https://github.com/midnightntwrk/midnight-js/commit/150ecd42952198d708ae1c9ef0289ff76d109793))
+* **testkit-js:** scope concurrency group by docker env ([#935](https://github.com/midnightntwrk/midnight-js/pull/935)) ([af794ca](https://github.com/midnightntwrk/midnight-js/commit/af794ca99673e7640ba2e2892aa1d6249b6a2858))
+
+
+### Improvements
+
+* **deps:** bump @midnight-ntwrk/wallet-sdk to 1.1.0 ([#919](https://github.com/midnightntwrk/midnight-js/pull/919)) ([0c59c4b](https://github.com/midnightntwrk/midnight-js/commit/0c59c4b960f9c14063cc9a0eeea1ff4635b56b98))
+* **deps:** bump dependencies to address security advisories ([#925](https://github.com/midnightntwrk/midnight-js/pull/925)) ([36d5aee](https://github.com/midnightntwrk/midnight-js/commit/36d5aeeb806af9416e5afc6cc25150c3f91038f6)), closes [#134](https://github.com/midnightntwrk/midnight-js/pull/134)
+* **deps:** bump testcontainers from 11.13.0 to 12.0.0 ([#928](https://github.com/midnightntwrk/midnight-js/pull/928)) ([ec14840](https://github.com/midnightntwrk/midnight-js/commit/ec148403b15bc7ac989c2830fa94e8910e9309a6))
+* **deps:** declare missing dependencies and enforce via ESLint ([#913](https://github.com/midnightntwrk/midnight-js/pull/913)) ([75cbc75](https://github.com/midnightntwrk/midnight-js/commit/75cbc7556b3abe504083c8365bc0e42ffee76987))
+* **deps:** enforce consistent dependency versions via Yarn Constraints ([#914](https://github.com/midnightntwrk/midnight-js/pull/914)) ([75085d3](https://github.com/midnightntwrk/midnight-js/commit/75085d391d527c78daef1ab60c8a8eaf84b12afc))
+* **deps:** remove unused root devDependencies, scope build-time deps to packages ([#916](https://github.com/midnightntwrk/midnight-js/pull/916)) ([b24283f](https://github.com/midnightntwrk/midnight-js/commit/b24283f32bd64dd540ef3206c1568c7cf4b1fac3))
+
+

--- a/src/components/DynamicListMidnightJS.js
+++ b/src/components/DynamicListMidnightJS.js
@@ -17,8 +17,17 @@ import { useLocation } from '@docusaurus/router';
 
 const releases = [
   {
-    version: '4.0.4',
+    version: '4.1.1',
     status: 'LATEST',
+    date: '07 June 2026',
+    summary: 'Summary of Release 4.1.1',
+    details: [],
+    artifacts: [],
+    link: '/relnotes/midnight-js/midnight-js-4-1-1',
+  },
+  {
+    version: '4.0.4',
+    status: 'SUPPORTED',
     date: '1 April 2026',
     summary: 'Summary of Release 4.0.4',
     details: [


### PR DESCRIPTION
Automated release notes copy for **midnight-js v4.1.1**.

Source: `https://github.com/midnightntwrk/midnight-js/releases/tag/v4.1.1`

### What to fill in manually

- [ ] `summary`: replace the placeholder in `src/components/DynamicListMidnightJS.js`
- [ ] `details`: add 5-8 bullet strings describing user-facing changes
- [ ] `artifacts`: add NPM/Docker links
- [ ] Reformat `docs/relnotes/midnight-js/midnight-js-4-1-1.mdx` to match the existing version file template