### PR TITLE
chore: remove ledger from compat

### DIFF
--- a/docs/relnotes/support-matrix.json
+++ b/docs/relnotes/support-matrix.json
@@ -66,18 +66,6 @@
       "notes": "On-chain runtime support (v3)"
     },
     {
-      "functionalArea": "Runtime and contracts",
-      "component": "Ledger",
-      "version": "8.0.3",
-      "notes": "Preprod / Mainnet"
-    },
-    {
-      "functionalArea": "Runtime and contracts",
-      "component": "Ledger",
-      "version": "8.1.0",
-      "notes": "Preview"
-    },
-    {
       "functionalArea": "SDKs and APIs",
       "component": "Wallet SDK facade",
       "version": "4.0.0",

--- a/docs/relnotes/support-matrix.mdx
+++ b/docs/relnotes/support-matrix.mdx
@@ -30,7 +30,6 @@ This matrix only reflects the latest tested versions. Earlier versions may still
 |                            | Compact JS                            | 2.5.1     | TypeScript execution environment for compiled contracts   |
 |                            | Platform JS                           | 2.2.4     | Core abstractions and types                               |
 |                            | On-chain runtime                      | 3.0.0     | On-chain runtime support (v3)                             |
-|                            | Ledger                                | 8.1.0     | Preview ledger                                            |
 | SDKs and APIs              | Wallet SDK facade                     | 4.0.0     | SDK for building wallet integrations                      |
 |                            | Midnight.js                           | 4.1.1     | DApp framework: contracts, types, providers               |
 |                            | testkit-js                            | 4.1.1     | E2E testing framework                                     |
@@ -50,7 +49,6 @@ This matrix only reflects the latest tested versions. Earlier versions may still
 |                            | Compact JS                            | 2.5.1     | TypeScript execution environment for compiled contracts   |
 |                            | Platform JS                           | 2.2.4     | Core abstractions and types                               |
 |                            | On-chain runtime                      | 3.0.0     | On-chain runtime support (v3)                             |
-|                            | Ledger                                | 8.0.3     | Preprod ledger                                            |
 | SDKs and APIs              | Wallet SDK facade                     | 4.0.0     | SDK for building wallet integrations                      |
 |                            | Midnight.js                           | 4.1.1     | DApp framework: contracts, types, providers               |
 |                            | testkit-js                            | 4.1.1     | E2E testing framework                                     |
@@ -70,7 +68,6 @@ This matrix only reflects the latest tested versions. Earlier versions may still
 |                            | Compact JS                            | 2.5.1     | TypeScript execution environment for compiled contracts   |
 |                            | Platform JS                           | 2.2.4     | Core abstractions and types                               |
 |                            | On-chain runtime                      | 3.0.0     | On-chain runtime support (v3)                             |
-|                            | Ledger                                | 8.0.3     | Mainnet ledger                                            |
 | SDKs and APIs              | Wallet SDK facade                     | 4.0.0     | SDK for building wallet integrations                      |
 |                            | Midnight.js                           | 4.1.1     | DApp framework: contracts, types, providers               |
 |                            | testkit-js                            | 4.1.1     | E2E testing framework                                     |


### PR DESCRIPTION
- With the release of MN js 4.1.x DApp developers no longer need to specify the ledger version, it is an internal dependency of the Midnight Node version