### PR TITLE
Add Wallets section to community SDKs and reorder sidebar

### DIFF
--- a/sdks/community/ai-tools/_category_.yaml
+++ b/sdks/community/ai-tools/_category_.yaml
@@ -1,4 +1,4 @@
-position: 20
+position: 10
 label: 'AI tools'
 collapsible: true
 collapsed: true

--- a/sdks/community/edda-midnight-starter.mdx
+++ b/sdks/community/edda-midnight-starter.mdx
@@ -1,7 +1,7 @@
 ---
 SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-sidebar_position: 20
+sidebar_position: 40
 sidebar_label: Edda Midnight starter
 description: "A full-stack starter template for building DApps on Midnight with a React frontend, Compact smart contract, CLI tooling, and educational materials."
 title: Edda Midnight starter template

--- a/sdks/community/midnight-live-view.mdx
+++ b/sdks/community/midnight-live-view.mdx
@@ -1,7 +1,7 @@
 ---
 SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-sidebar_position: 30
+sidebar_position: 50
 sidebar_label: Midnight Live View
 description: A real-time terminal dashboard and persistent block monitor for Midnight validator nodes, inspired by CNTool's gLiveView.
 title: Midnight Live View

--- a/sdks/community/openzeppelin-compact-contracts.mdx
+++ b/sdks/community/openzeppelin-compact-contracts.mdx
@@ -1,7 +1,7 @@
 ---
 SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-sidebar_position: 10
+sidebar_position: 30
 sidebar_label: OpenZeppelin compact contracts
 description: A library of token standards, access control, and security primitives for Compact smart contracts, modeled on OpenZeppelin's Solidity contracts.
 title: OpenZeppelin contracts for Compact

--- a/sdks/community/wallets/_category_.yaml
+++ b/sdks/community/wallets/_category_.yaml
@@ -1,0 +1,8 @@
+position: 20
+label: 'Wallets'
+collapsible: true
+collapsed: true
+link:
+  type: generated-index
+  title: Community wallets
+  description: Community-built wallet integrations for the Midnight Network.

--- a/sdks/community/wallets/wallets-overview.mdx
+++ b/sdks/community/wallets/wallets-overview.mdx
@@ -1,0 +1,23 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+sidebar_position: 10
+sidebar_label: Overview
+description: Community-built wallet integrations for interacting with the Midnight Network.
+title: Community wallets
+tags: [community, wallets, integration]
+toc_max_heading_level: 2
+id: community-wallets-overview
+---
+
+# Community wallets
+
+Community-built wallet integrations for interacting with the Midnight Network. These projects extend wallet support beyond the official Midnight Lace wallet.
+
+:::warning[Community-maintained - not officially supported]
+
+Their respective authors maintain the projects listed here, not the Midnight Foundation. Verify compatibility against the [compatibility matrix](/relnotes/support-matrix) before integrating. File issues with each project's maintainers directly.
+
+:::
+
+Check back for new wallet integrations as the community grows.


### PR DESCRIPTION
Adds a new Wallets subsection under Community and reorders the sidebar so AI tools and Wallets appear before OpenZeppelin and other project pages.
