### PR TITLE
chore: sdk instead of facade

### DIFF
--- a/docs/relnotes/support-matrix.json
+++ b/docs/relnotes/support-matrix.json
@@ -67,8 +67,8 @@
     },
     {
       "functionalArea": "SDKs and APIs",
-      "component": "Wallet SDK facade",
-      "version": "4.0.0",
+      "component": "Wallet SDK",
+      "version": "1.0.0",
       "notes": "SDK for building wallet integrations"
     },
     {

--- a/docs/relnotes/support-matrix.mdx
+++ b/docs/relnotes/support-matrix.mdx
@@ -30,7 +30,7 @@ This matrix only reflects the latest tested versions. Earlier versions may still
 |                            | Compact JS                            | 2.5.1     | TypeScript execution environment for compiled contracts   |
 |                            | Platform JS                           | 2.2.4     | Core abstractions and types                               |
 |                            | On-chain runtime                      | 3.0.0     | On-chain runtime support (v3)                             |
-| SDKs and APIs              | Wallet SDK facade                     | 4.0.0     | SDK for building wallet integrations                      |
+| SDKs and APIs              | Wallet SDK                            | 1.0.0     | SDK for building wallet integrations                      |
 |                            | Midnight.js                           | 4.1.1     | DApp framework: contracts, types, providers               |
 |                            | testkit-js                            | 4.1.1     | E2E testing framework                                     |
 |                            | DApp Connector API                    | 4.0.1     | Interface between DApps and wallets                       |
@@ -49,7 +49,7 @@ This matrix only reflects the latest tested versions. Earlier versions may still
 |                            | Compact JS                            | 2.5.1     | TypeScript execution environment for compiled contracts   |
 |                            | Platform JS                           | 2.2.4     | Core abstractions and types                               |
 |                            | On-chain runtime                      | 3.0.0     | On-chain runtime support (v3)                             |
-| SDKs and APIs              | Wallet SDK facade                     | 4.0.0     | SDK for building wallet integrations                      |
+| SDKs and APIs              | Wallet SDK                            | 1.0.0     | SDK for building wallet integrations                      |
 |                            | Midnight.js                           | 4.1.1     | DApp framework: contracts, types, providers               |
 |                            | testkit-js                            | 4.1.1     | E2E testing framework                                     |
 |                            | DApp Connector API                    | 4.0.1     | Interface between DApps and wallets                       |
@@ -68,7 +68,7 @@ This matrix only reflects the latest tested versions. Earlier versions may still
 |                            | Compact JS                            | 2.5.1     | TypeScript execution environment for compiled contracts   |
 |                            | Platform JS                           | 2.2.4     | Core abstractions and types                               |
 |                            | On-chain runtime                      | 3.0.0     | On-chain runtime support (v3)                             |
-| SDKs and APIs              | Wallet SDK facade                     | 4.0.0     | SDK for building wallet integrations                      |
+| SDKs and APIs              | Wallet SDK                            | 1.0.0     | SDK for building wallet integrations                      |
 |                            | Midnight.js                           | 4.1.1     | DApp framework: contracts, types, providers               |
 |                            | testkit-js                            | 4.1.1     | E2E testing framework                                     |
 |                            | DApp Connector API                    | 4.0.1     | Interface between DApps and wallets                       |


### PR DESCRIPTION
- wallet-sdk now acts as a barrel package for other wallet packages, so only the wallet-sdk needs to be imported