### PR TITLE
docs(compact): add "Disclosing low-entropy values safely" to explicit-disclosure

### DIFF
--- a/docs/compact/reference/explicit-disclosure.mdx
+++ b/docs/compact/reference/explicit-disclosure.mdx
@@ -151,6 +151,39 @@ The message aids the programmer by noting the indirect nature of the disclosure.
 
 The compiler recognizes that certain Compact standard library routines sufficiently disguise witness data so that explicit declaration of disclosure is not required. For an expression `e` whose value contains witness data, the compiler will treat `transientCommit(e)` as if it does not contain witness data, while it will treat `transientHash(e)` as if it does.
 
+## Disclosing low-entropy values safely
+
+Declaring disclosure with `disclose()`, or relying on a routine that the compiler treats as safe, controls only *when* the compiler permits a value to reach the public ledger. It does not, by itself, guarantee that the underlying private value stays secret. When the disclosed value is derived from witness data that can take only a small number of possible values, an observer can often recover the original value by brute force.
+
+Consider a contract that records a yes/no vote. The vote has only two possible values, so disclosing a hash of it reveals it: the compiler requires the `disclose()` wrapper because a hash is still treated as witness data, but declaring the disclosure does not make the vote secret. An observer simply hashes both `0` and `1` and compares.
+
+```compact
+import CompactStandardLibrary;
+witness localVote(): Field;          // a yes/no vote: only 0 or 1
+export ledger recordedVote: Bytes<32>;
+
+// Unsafe: an observer can hash both possible votes and match the result.
+export circuit recordVoteUnsafe(): [] {
+  recordedVote = disclose(persistentHash<Field>(localVote()));
+}
+```
+
+A commitment avoids this, but only when it is combined with randomness that is secret, high-entropy, and never reused. The `transientCommit` and `persistentCommit` routines take a separate randomness argument for exactly this purpose, and the compiler treats their results as sufficiently protected, so no `disclose()` wrapper is required.
+
+```compact
+import CompactStandardLibrary;
+witness localVote(): Field;          // a yes/no vote: only 0 or 1
+witness voteSalt(): Bytes<32>;       // fresh, secret, and unique per commitment
+export ledger recordedVote: Bytes<32>;
+
+// Safe: a fresh secret salt hides the vote, even though it has low entropy.
+export circuit recordVoteSafe(): [] {
+  recordedVote = persistentCommit<Field>(localVote(), voteSalt());
+}
+```
+
+The compiler does not verify that the randomness is actually secret, high-entropy, or unique. A commitment built with a predictable, derivable, or reused salt is no longer hiding, even though the compiler still accepts it without a `disclose()` wrapper: identical inputs produce identical commitments, which links them and can again expose the value. Choose fresh randomness for every commitment, and prefer a commitment over a plain hash whenever the disclosed value is drawn from a small or guessable set.
+
 ## How explicit disclosure is implemented
 
 We refer to the portion of the compiler that detects and reports undeclared disclosure of witness data as the "witness protection program". The witness-protection program is implemented as an _abstract interpreter_, where the abstract values are not actual run-time values but information about witness data that will be contained within the actual run-time values.


### PR DESCRIPTION
## What
Adds a new section, "Disclosing low-entropy values safely", to `docs/compact/reference/explicit-disclosure.mdx`, right after the existing "Safe Compact standard library routines" section.

## Why
The page explains that the compiler treats `transientCommit` and `persistentCommit` as safe to disclose, but it does not warn about a common and subtle pitfall: disclosing a hash, or a commitment built with weak randomness, of a low-entropy value does not keep that value secret. An observer can brute-force the small input space. On a privacy chain this is exactly the kind of mistake that leaks "private" data, so it is worth calling out where developers learn about disclosure.

## What the section adds
- A plain explanation that `disclose()`, and the compiler's "safe" treatment of commitments, controls when disclosure is permitted, not whether the value stays secret in practice.
- A worked unsafe example (disclosing `persistentHash` of a yes/no vote) and the safe alternative (`persistentCommit` with a fresh secret salt).
- A note that the compiler does not verify the commitment's randomness is secret, fresh, or unique, so a reused or predictable salt re-exposes the value.

All Compact signatures used (`persistentHash<T>(value): Bytes<32>`, `persistentCommit<T>(value, rand: Bytes<32>): Bytes<32>`) match the standard library reference.
