### PR TITLE
Fix ~120 Compact-touching 404 URLs via vercel.json redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -605,6 +605,137 @@
         "source": "/wallet-api/README.md",
         "destination": "/sdks/official/wallet-developer-guide",
         "permanent": true
+      },
+
+      {
+        "source": "/compact/reference/midnight-api/:path*",
+        "destination": "/api-reference/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/compact/compact-grammar",
+        "destination": "/compact/reference/compact-grammar",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/compact/compact-std-library/:path*",
+        "destination": "/compact/standard-library",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/compact/compact-std-library",
+        "destination": "/compact/standard-library",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/compact/ledger-adt",
+        "destination": "/compact/reference/ledger-adt",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/compact/:path*",
+        "destination": "/compact/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/compact",
+        "destination": "/compact",
+        "permanent": true
+      },
+      {
+        "source": "/develop/compact/:path*",
+        "destination": "/compact/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/develop/compact",
+        "destination": "/compact",
+        "permanent": true
+      },
+      {
+        "source": "/learn/compact",
+        "destination": "/compact",
+        "permanent": true
+      },
+      {
+        "source": "/next/compact/:path*",
+        "destination": "/compact/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/next/compact",
+        "destination": "/compact",
+        "permanent": true
+      },
+      {
+        "source": "/next/category/standard-library",
+        "destination": "/compact/standard-library",
+        "permanent": true
+      },
+      {
+        "source": "/next/category/compilation-and-tooling",
+        "destination": "/compact/compilation-and-tooling",
+        "permanent": true
+      },
+      {
+        "source": "/next/category/reference",
+        "destination": "/compact/reference",
+        "permanent": true
+      },
+      {
+        "source": "/next/concepts/reference/compact/:path*",
+        "destination": "/compact/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/concepts/reference/compact/:path*",
+        "destination": "/compact/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/reference/compact/:path*",
+        "destination": "/compact/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/compact/writing.mdx",
+        "destination": "/compact/reference/writing",
+        "permanent": true
+      },
+      {
+        "source": "/compact/explicit_disclosure",
+        "destination": "/compact/reference/explicit-disclosure",
+        "permanent": true
+      },
+      {
+        "source": "/compact/reference/explicit_disclosure",
+        "destination": "/compact/reference/explicit-disclosure",
+        "permanent": true
+      },
+      {
+        "source": "/compact/language-reference",
+        "destination": "/compact/reference",
+        "permanent": true
+      },
+      {
+        "source": "/compact/reference/all-keywords",
+        "destination": "/compact/reference",
+        "permanent": true
+      },
+      {
+        "source": "/compact/reference/lang-ref",
+        "destination": "/compact/reference",
+        "permanent": true
+      },
+      {
+        "source": "/compact/reference/tools/vsc-plugin",
+        "destination": "/relnotes/overview",
+        "permanent": true
+      },
+      {
+        "source": "/compact/reference/tools",
+        "destination": "/compact/compilation-and-tooling",
+        "permanent": true
       }
     ],
     "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -736,6 +736,26 @@
         "source": "/compact/reference/tools",
         "destination": "/compact/compilation-and-tooling",
         "permanent": true
+      },
+      {
+        "source": "/compact/reference/midnight-api",
+        "destination": "/api-reference",
+        "permanent": true
+      },
+      {
+        "source": "/next/concepts/reference/compact",
+        "destination": "/compact",
+        "permanent": true
+      },
+      {
+        "source": "/concepts/reference/compact",
+        "destination": "/compact",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/reference/compact",
+        "destination": "/compact",
+        "permanent": true
       }
     ],
     "rewrites": [


### PR DESCRIPTION
## Summary

Adds 26 redirect rules to `vercel.json` covering ~120 URLs that currently 404 and either start with `/compact/...` (source side) or point at destinations inside `/docs/compact/` (destination side).

Companion to #1047 which covered the non-Compact bulk.

The largest rule is the single wildcard `/compact/reference/midnight-api/:path*` → `/api-reference/:path*`, which alone covers ~100 of the 120 URLs.





