### PR TITLE
Strip trailing slashes via vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
     "cleanUrls": true,
+    "trailingSlash": false,
     "redirects": [
       {
         "source": "/academy",


### PR DESCRIPTION
## Summary

Adds `"trailingSlash": false` to `vercel.json` so Vercel automatically redirects URLs with trailing slashes (e.g. `/develop/tutorial/building/`) to the canonical form without one (`/develop/tutorial/building`).

Without this, redirect rules like `/develop/tutorial/building` and `/develop/tutorial/building/:path*` do not match the trailing-slash variant, causing 404s when users visit URLs that happen to have a trailing slash.
