### PR TITLE
docs: fix wallet discovery using fixed window.midnight.mnLace key

### DIFF
--- a/docs/guides/nextjs-wallet-connect.mdx
+++ b/docs/guides/nextjs-wallet-connect.mdx
@@ -81,9 +81,15 @@ export default function ConnectWalletButton() {
 
   const handleConnect = async () => {
     try {
-      // Access the Midnight Lace wallet through the window object
-      const wallet: InitialAPI = await window.midnight!.mnLace;
-      
+      // Wallets inject their Initial API into `window.midnight` under a
+      // wallet-specific key (not a fixed key like `mnLace`), so look it up
+      // by the `name` property instead of assuming the key.
+      const wallets = Object.values(window.midnight ?? {});
+      const wallet: InitialAPI | undefined = wallets.find((w) => w.name === 'Lace');
+      if (!wallet) {
+        throw new Error('Lace wallet not found. Please install the Lace wallet extension.');
+      }
+
       // Connect to the specified network (use 'undeployed' for local development)
       const connectedApi = await wallet.connect('preprod');
       
@@ -134,7 +140,7 @@ This component manages the wallet connection flow:
 
 1. **Client-side rendering**: The `"use client"` directive ensures this component runs in the browser where wallet APIs are available.
 2. **State management**: Uses React's `useState` hook to track connection status and wallet address.
-3. **Connection logic**: The `handleConnect` function accesses the wallet through `window.midnight.mnLace`, connects to the specified network, and retrieves the wallet's shielded address.
+3. **Connection logic**: The `handleConnect` function looks up the Lace wallet from `window.midnight` by its `name` property, connects to the specified network, and retrieves the wallet's shielded address.
 4. **User feedback**: Displays the wallet address (truncated) and provides connect/disconnect actions.
 
 </Step>

--- a/docs/guides/react-wallet-connect.mdx
+++ b/docs/guides/react-wallet-connect.mdx
@@ -149,9 +149,15 @@ const App: React.FC = () => {
     let address = null;
     
     try {
-      // Access the Midnight Lace wallet through the window object
-      const wallet: InitialAPI = window.midnight!.mnLace;
-      
+      // Wallets inject their Initial API into `window.midnight` under a
+      // wallet-specific key (not a fixed key like `mnLace`), so look it up
+      // by the `name` property instead of assuming the key.
+      const wallets = Object.values(window.midnight ?? {});
+      const wallet: InitialAPI | undefined = wallets.find((w) => w.name === 'Lace');
+      if (!wallet) {
+        throw new Error('Lace wallet not found. Please install the Lace wallet extension.');
+      }
+
       // Connect to the specified network (use 'undeployed' for local development)
       const connectedApi = await wallet.connect('preprod');
       
@@ -204,8 +210,8 @@ export default App;
 
 Let's break down the wallet connection process:
 
-1. **Access the wallet**: The DApp Connector API exposes the wallet through `window.midnight.{walletProvider}`. 
-In our example, we used `window.midnight.mnLace` to access the Midnight Lace wallet.
+1. **Access the wallet**: The DApp Connector API exposes each wallet through `window.midnight.{walletId}`, where `{walletId}` is a wallet-specific key chosen by the wallet (not a fixed value). 
+In our example, we find the Lace wallet by looking up `window.midnight` values whose `name` property is `'Lace'`.
 2. **Connect to network**: Call the `connect()` method and pass the network ID as an argument. 
 In our example, we used `'undeployed'` for local development. You can use `'preview'` for the Preview testnet or `'preprod'` for the PreProd network.
 3. **Retrieve addresses**: After connecting to the network, call the `getShieldedAddresses()` method to get the wallet's shielded address.

--- a/sdks/official/wallet-dev-guide.mdx
+++ b/sdks/official/wallet-dev-guide.mdx
@@ -793,8 +793,10 @@ The example below shows how a DApp connects to and interacts with a Lace Midnigh
 ```typescript
 import { nativeToken } from '@midnight-ntwrk/ledger-v8';
 
-// Check if wallet is available
-const wallet = window.midnight?.mnLace;
+// Wallets inject their Initial API into `window.midnight` under a
+// wallet-specific key (not a fixed key like `mnLace`), so look it up
+// by the `name` property instead of assuming the key.
+const wallet = Object.values(window.midnight ?? {}).find((w) => w.name === 'Lace');
 
 if (!wallet) {
   console.error('Please install Lace Midnight wallet');


### PR DESCRIPTION
## Summary

Fixes #1070.

The DApp Connector API spec ([SPECIFICATION.md](https://github.com/midnightntwrk/midnight-docs/blob/main/api-reference/dapp-connector/_media/SPECIFICATION.md)) has wallets install their `InitialAPI` under `window.midnight` keyed by a wallet-chosen identifier (typically a freshly-generated UUID), not a fixed property name. The official API reference itself documents discovery via `Object.values(window.midnight ?? {})` (see `api-reference/dapp-connector/README.md`), and `sdks/community/wallets/integration.mdx` documents the same `Object.values` scan as the recommended v4 pattern.

Three guides/docs in this repo instead hardcoded `window.midnight.mnLace`, which is `undefined` against current Lace builds and produces exactly the error reported in #1070:

```
TypeError: Cannot read properties of undefined (reading 'connect')
```

- `docs/guides/react-wallet-connect.mdx` — the guide named in the issue
- `docs/guides/nextjs-wallet-connect.mdx` — same anti-pattern, same root cause
- `sdks/official/wallet-dev-guide.mdx` — DApp integration example with the same bug

All three now discover the wallet via `Object.values(window.midnight ?? {}).find((w) => w.name === 'Lace')`, consistent with the discovery pattern already documented elsewhere in this repo.

## Test plan

- [x] Confirmed against `api-reference/dapp-connector/_media/SPECIFICATION.md` and `api-reference/dapp-connector/README.md` that wallets are keyed by a wallet-chosen id (not a fixed property), and that `Object.values(window.midnight ?? {})` is the documented discovery pattern.
- [x] Confirmed `InitialAPI.name` and `InitialAPI.rdns` are documented properties suitable for selecting a specific wallet (`api-reference/dapp-connector/type-aliases/InitialAPI.md`).
- [x] Maintainers/reporter to confirm the fix resolves the "Connect Wallet" button against a real Lace install (I don't have the extension installed in this environment to do a live click-through).