### PR TITLE
chore: update tutorial to latest code

### DIFF
--- a/docs/tutorials/zk-loan/attestation-api.mdx
+++ b/docs/tutorials/zk-loan/attestation-api.mdx
@@ -93,7 +93,7 @@ import {
   jubjubPointX,
   jubjubPointY,
   type JubjubPoint,
-} from "@midnight-ntwrk/compact-runtime";
+} from "@midnight-ntwrk/midnight-js-protocol/compact-runtime";
 import { ZKLoanCreditScorer } from "zkloan-credit-scorer-contract";
 const { pureCircuits } = ZKLoanCreditScorer;
 
@@ -199,7 +199,7 @@ import {
   jubjubPointX,
   jubjubPointY,
   type JubjubPoint,
-} from '@midnight-ntwrk/compact-runtime';
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 
 export function createServer(
   providerSk: bigint,
@@ -325,7 +325,7 @@ Create a file `index.ts` inside the `zkloan-credit-scorer-attestation-api/src` f
 import {
   jubjubPointX,
   jubjubPointY,
-} from '@midnight-ntwrk/compact-runtime';
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { createServer } from './server.js';
 import { generateKeyPair, getPublicKey } from './signing.js';
@@ -390,8 +390,9 @@ Create a `package.json` file inside the root `zkloan-credit-scorer-attestation-a
   },
   "dependencies": {
     "zkloan-credit-scorer-contract": "0.1.0",
-    "@midnight-ntwrk/compact-runtime": "0.15.0",
-    "@midnight-ntwrk/midnight-js-network-id": "4.0.4",
+    "@midnight-ntwrk/compact-runtime": "^0.16.0",
+    "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+    "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
     "restify": "^11.1.0"
   },
   "devDependencies": {
@@ -400,6 +401,8 @@ Create a `package.json` file inside the root `zkloan-credit-scorer-attestation-a
   }
 }
 ```
+
+The attestation API pulls `ecMulGenerator`, `jubjubPointX`, `jubjubPointY`, and `JubjubPoint` from `@midnight-ntwrk/midnight-js-protocol/compact-runtime`, so `midnight-js-protocol` is a direct dep here. `@midnight-ntwrk/compact-runtime` stays too because the generated contract code (imported transitively through `zkloan-credit-scorer-contract`) needs it at runtime.
 
 Next, create `zkloan-credit-scorer-attestation-api/tsconfig.json` with the following code snippet:
 
@@ -412,7 +415,7 @@ Next, create `zkloan-credit-scorer-attestation-api/tsconfig.json` with the follo
     "lib": ["ESNext"],
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
@@ -426,6 +429,8 @@ Next, create `zkloan-credit-scorer-attestation-api/tsconfig.json` with the follo
   "include": ["src/**/*.ts"]
 }
 ```
+
+`moduleResolution` is `bundler` (rather than the legacy `node`) so TypeScript can read the `exports` subpath map that `@midnight-ntwrk/midnight-js-protocol` uses to publish `/compact-runtime`, `/ledger`, and `/compact-js`. `node16` and `nodenext` work too.
 
 ## Understanding the attestation flow
 
@@ -502,7 +507,7 @@ services:
 ```
 
 :::note
-Make sure you are using the latest version of the proof server. Check the [compatibility matrix](/relnotes/compact-js) to verify the correct version for your SDK.
+Make sure you are using the latest version of the proof server. Check the [compatibility matrix](/relnotes/support-matrix) to verify the correct version for your SDK.
 :::
 
 Start the proof server:

--- a/docs/tutorials/zk-loan/cli.mdx
+++ b/docs/tutorials/zk-loan/cli.mdx
@@ -353,14 +353,14 @@ import {
   type ContractAddress,
   transientHash,
   CompactTypeBytes,
-} from '@midnight-ntwrk/compact-runtime';
+} from '@midnight-ntwrk/midnight-js-protocol/compact-runtime';
 import {
   ZKLoanCreditScorer,
   type ZKLoanCreditScorerPrivateState,
   witnesses,
 } from 'zkloan-credit-scorer-contract';
-import * as ledger from '@midnight-ntwrk/ledger-v8';
-import { CompiledContract } from '@midnight-ntwrk/compact-js';
+import * as ledger from '@midnight-ntwrk/midnight-js-protocol/ledger';
+import { CompiledContract } from '@midnight-ntwrk/midnight-js-protocol/compact-js';
 import {
   deployContract,
   findDeployedContract,
@@ -378,17 +378,21 @@ import {
 import { assertIsContractAddress } from '@midnight-ntwrk/midnight-js-utils';
 import { setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 
-import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
-import { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
-import { ShieldedWallet } from '@midnight-ntwrk/wallet-sdk-shielded';
-import { DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
+// Wallet SDK imports are consolidated under the @midnight-ntwrk/wallet-sdk
+// barrel (introduced in wallet-sdk 1.1.0, alongside Midnight JS 4.1.x).
 import {
+  HDWallet,
+  Roles,
+  WalletFacade,
+  ShieldedWallet,
+  DustWallet,
+  UnshieldedWallet,
   createKeystore,
   InMemoryTransactionHistoryStorage,
+  WalletEntrySchema,
   PublicKey as UnshieldedPublicKey,
   type UnshieldedKeystore,
-  UnshieldedWallet,
-} from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
+} from '@midnight-ntwrk/wallet-sdk';
 import * as bip39 from '@scure/bip39';
 import { wordlist as english } from '@scure/bip39/wordlists/english.js';
 
@@ -413,6 +417,15 @@ globalThis.WebSocket = WebSocket;
 ```
 
 The `WebSocket` assignment is required because the Midnight SDK's GraphQL subscriptions (used by the indexer) expect a global WebSocket constructor. Node.js does not provide one by default.
+
+:::note Two Midnight JS 4.1.x import changes
+
+- **Protocol packages go through the ACL package.** Hand-written imports for `ledger`, `compact-runtime`, `compact-js`, `onchain-runtime`, and `platform-js` are rewritten as subpath imports of the version-agnostic `@midnight-ntwrk/midnight-js-protocol` package (for example, `@midnight-ntwrk/midnight-js-protocol/compact-runtime`). Direct `@midnight-ntwrk/ledger-v8` and `@midnight-ntwrk/compact-js` imports no longer belong in application code.
+- **Wallet SDK collapses to a single barrel.** `wallet-sdk-facade`, `wallet-sdk-hd`, `wallet-sdk-shielded`, `wallet-sdk-dust-wallet`, and `wallet-sdk-unshielded-wallet` are re-exported from `@midnight-ntwrk/wallet-sdk` (1.1.0). Import one place, not five.
+
+Both changes require `tsconfig.json` with `moduleResolution` set to `bundler`, `node16`, or `nodenext` — the legacy `node` resolver cannot read the protocol package's `exports` subpath map. See the tsconfig block later in this section.
+
+:::
 
 #### Wallet context and ledger state
 
@@ -505,6 +518,12 @@ The code above defines three key exports:
 *   `deploy` creates a new instance of the smart contract on Preprod. This triggers a deployment transaction that includes a ZK proof — the proof server generates this, which takes about a minute.
 
 *   `joinContract` connects to an existing deployed smart contract by address. This is how a second user (or the same user in a new session) interacts with a smart contract deployed by someone else.
+
+:::note `args` is conditionally typed in 4.1.x
+
+`deployContract`'s `args` option is now conditionally typed on the contract's constructor signature. This contract's constructor takes no arguments, so `args` must be **omitted entirely** — passing `args: []` no longer type-checks. If your contract had a constructor with parameters, `args` would become required and typed to match those parameters.
+
+:::
 
 #### Attestation and loan request logic
 
@@ -1034,6 +1053,11 @@ export const initWalletWithSeed = async (
     },
     provingServerUrl: new URL(config.proofServer),
     relayURL,
+    // As of wallet-sdk 1.x, every wallet variant's default configuration
+    // (shielded / unshielded / dust) requires its own transaction-history
+    // storage. `InMemoryTransactionHistoryStorage` now takes a schema —
+    // the barrel re-exports `WalletEntrySchema` for exactly this use.
+    txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
   };
 
   const unshieldedConfig = {
@@ -1042,7 +1066,7 @@ export const initWalletWithSeed = async (
       indexerHttpUrl: config.indexer,
       indexerWsUrl: config.indexerWS,
     },
-    txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+    txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
   };
 
   const dustConfig = {
@@ -1057,6 +1081,7 @@ export const initWalletWithSeed = async (
     },
     provingServerUrl: new URL(config.proofServer),
     relayURL,
+    txHistoryStorage: new InMemoryTransactionHistoryStorage(WalletEntrySchema),
   };
 
   // Combine the per-wallet configs into a single configuration the facade
@@ -1652,7 +1677,7 @@ Create `zkloan-credit-scorer-cli/tsconfig.json`:
     "lib": ["ESNext"],
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
@@ -1669,6 +1694,8 @@ Create `zkloan-credit-scorer-cli/tsconfig.json`:
   }
 }
 ```
+
+`moduleResolution` must be `bundler` (or `node16`/`nodenext`) so TypeScript can read the `exports` subpath map published by `@midnight-ntwrk/midnight-js-protocol`. The legacy `node` resolver silently fails to find `/compact-runtime`, `/ledger`, and `/compact-js`.
 
 Create `zkloan-credit-scorer-cli/tsconfig.build.json`:
 

--- a/docs/tutorials/zk-loan/smart-contract.mdx
+++ b/docs/tutorials/zk-loan/smart-contract.mdx
@@ -36,7 +36,7 @@ node --version
 ```
 
 :::caution Node 20 will crash mid-sync
-This DApp uses `@midnight-ntwrk/wallet-sdk-shielded`, which calls `Map.prototype.values().map(...)` on the shielded wallet state. That requires the [Iterator helpers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) added in Node 22. On Node 20 the wallet appears to start, then crashes on the first sync update with `state.pendingOutputs.values.map is not a function`. If you use [nvm](https://github.com/nvm-sh/nvm), add a `.nvmrc` file containing `22` (or your preferred 22+ release) to the repo root so `nvm use` picks it up automatically.
+This DApp uses the `@midnight-ntwrk/wallet-sdk` barrel (re-exports the shielded wallet), which calls `Map.prototype.values().map(...)` on the shielded wallet state. That requires the [Iterator helpers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) added in Node 22. On Node 20 the wallet appears to start, then crashes on the first sync update with `state.pendingOutputs.values.map is not a function`. If you use [nvm](https://github.com/nvm-sh/nvm), add a `.nvmrc` file containing `22` (or your preferred 22+ release) to the repo root so `nvm use` picks it up automatically.
 :::
 
 Install the Midnight Compact compiler. Follow the instructions in the [installation guide](/getting-started/installation) to install the Compact toolchain on your system.
@@ -49,9 +49,9 @@ compact compile --version
 
 Run `compact update` to install the latest Compact toolchain. The workspace `package.json` declares `@midnight-ntwrk/compact-runtime: ^0.16.0`, which matches what the latest `compact compile` emits.
 
-:::note compact-js's nested compact-runtime
+:::note Midnight JS 4.1.x protocol ACL
 
-`compact-js@2.5.0` declares an exact-pin on `compact-runtime@0.15.0`, but that pin only applies to compact-js's internal resolution — npm nests the `0.15` build inside `node_modules/@midnight-ntwrk/compact-js/node_modules/` and serves `0.16` to your application code at the top level. There is no workspace-level version conflict, and you do not need to do anything about the nested copy.
+As of Midnight JS **4.1.x**, hand-written code no longer imports the protocol packages (`ledger`, `compact-runtime`, `compact-js`, `onchain-runtime`, `platform-js`) directly. They are consumed through the version-agnostic **`@midnight-ntwrk/midnight-js-protocol`** ACL package via subpath imports — for example, `@midnight-ntwrk/midnight-js-protocol/compact-runtime`. `@midnight-ntwrk/compact-runtime` is still declared as a direct dependency because the compiler-generated contract code imports it directly, but every hand-written import points at the protocol subpath instead. This decouples your code from a specific ledger major version.
 
 :::
 
@@ -91,23 +91,18 @@ cat > package.json << 'EOF'
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@midnight-ntwrk/compact-js": "^2.5.0",
     "@midnight-ntwrk/compact-runtime": "^0.16.0",
-    "@midnight-ntwrk/ledger-v8": "8.0.3",
-    "@midnight-ntwrk/midnight-js-contracts": "4.0.4",
-    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-network-id": "4.0.4",
-    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.0.4",
-    "@midnight-ntwrk/midnight-js-types": "4.0.4",
-    "@midnight-ntwrk/midnight-js-utils": "4.0.4",
-    "@midnight-ntwrk/wallet-sdk-address-format": "3.1.0",
-    "@midnight-ntwrk/wallet-sdk-dust-wallet": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-facade": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-shielded": "2.1.0",
-    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "2.1.0",
+    "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-protocol": "4.1.1",
+    "@midnight-ntwrk/midnight-js-types": "4.1.1",
+    "@midnight-ntwrk/midnight-js-utils": "4.1.1",
+    "@midnight-ntwrk/wallet-sdk": "1.1.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "3.1.2",
     "@scure/bip39": "^2.0.1",
     "dotenv": "^17.2.3",
     "pino": "^10.1.0",
@@ -117,16 +112,25 @@ cat > package.json << 'EOF'
   },
   "overrides": {
     "smoldot": "npm:@aspect-build/empty@0.0.0",
-    "@midnight-ntwrk/ledger-v8": "8.0.3",
-    "@midnight-ntwrk/midnight-js-network-id": "4.0.4"
+    "@midnight-ntwrk/ledger-v8": "8.1.0",
+    "@midnight-ntwrk/midnight-js-network-id": "4.1.1"
   },
   "resolutions": {
-    "@midnight-ntwrk/ledger-v8": "8.0.3",
-    "@midnight-ntwrk/midnight-js-network-id": "4.0.4"
+    "@midnight-ntwrk/ledger-v8": "8.1.0",
+    "@midnight-ntwrk/midnight-js-network-id": "4.1.1"
   }
 }
 EOF
 ```
+
+:::note What changed vs. 4.0.x
+
+- Direct `@midnight-ntwrk/compact-js` and `@midnight-ntwrk/ledger-v8` deps are gone — both are consumed through `@midnight-ntwrk/midnight-js-protocol` (added).
+- The five individual wallet-sdk subpackages (`-facade`, `-hd`, `-shielded`, `-dust-wallet`, `-unshielded-wallet`) collapse to the single `@midnight-ntwrk/wallet-sdk` barrel.
+- All `@midnight-ntwrk/midnight-js-*` packages step to `4.1.1`; the wrapped ledger pinned via `overrides`/`resolutions` moves to `8.1.0`.
+- `@midnight-ntwrk/compact-runtime` stays as a direct dep because the compiler-generated contract code imports it directly.
+
+:::
 
 Next, create the `.gitignore` with the following command:
 
@@ -648,7 +652,7 @@ Create `contract/src/witnesses.ts`:
 
 ```typescript
 import { Ledger } from "./managed/zkloan-credit-scorer/contract/index.js";
-import { WitnessContext } from "@midnight-ntwrk/compact-runtime";
+import { WitnessContext } from "@midnight-ntwrk/midnight-js-protocol/compact-runtime";
 
 export type SchnorrSignature = {
   announcement: { x: bigint; y: bigint };
@@ -784,7 +788,7 @@ cat > contract/tsconfig.json << 'EOF'
     "lib": ["ESNext"],
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
@@ -798,6 +802,12 @@ cat > contract/tsconfig.json << 'EOF'
 }
 EOF
 ```
+
+:::note `moduleResolution: bundler` is required
+
+Midnight JS 4.1.x uses the protocol package's `exports` subpath map (`@midnight-ntwrk/midnight-js-protocol/compact-runtime`, `/ledger`, `/compact-js`, etc.). The legacy `moduleResolution: node` resolver cannot read that map. Use `bundler`, `node16`, or `nodenext` in every workspace that imports from a protocol subpath.
+
+:::
 
 Create `contract/tsconfig.build.json`:
 


### PR DESCRIPTION
   Align the three ZK Loan tutorial files with the example-zkloan repo at the
   Midnight JS 4.1.1 / wallet-sdk 1.1.0 state.

   smart-contract.mdx:
   - Reword the Node 20 caution to reference the @midnight-ntwrk/wallet-sdk
     barrel instead of the removed wallet-sdk-shielded package.
   - Replace the obsolete "compact-js nested compact-runtime" note with a
     4.1.x protocol-ACL note explaining midnight-js-protocol subpath imports.
   - Rewrite the root package.json snippet: drop direct compact-js and
     ledger-v8 deps, add midnight-js-protocol, collapse the five wallet-sdk-*
     deps to the single @midnight-ntwrk/wallet-sdk barrel, step all
     midnight-js-* to 4.1.1, and pin ledger-v8 to 8.1.0 in
     overrides/resolutions. Add a "what changed vs. 4.0.x" callout.
   - Switch the WitnessContext import to
     @midnight-ntwrk/midnight-js-protocol/compact-runtime.
   - Contract tsconfig: moduleResolution "node" -> "bundler", with an
     explanatory note.

   attestation-api.mdx:
   - Rewrite the three @midnight-ntwrk/compact-runtime imports (signing,
     server, index) to use the midnight-js-protocol/compact-runtime subpath.
   - package.json: compact-runtime ^0.16.0, add midnight-js-protocol 4.1.1,
     bump midnight-js-network-id to 4.1.1, with an explanatory note.
   - tsconfig: moduleResolution "node" -> "bundler", with an explanatory note.
   - Fix stale /relnotes/compact-js compatibility-matrix link to
     /relnotes/support-matrix.