### PR TITLE
Fix redirect chains that end on removed or renamed pages

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -40,6 +40,21 @@
       },
       
       {
+        "source": "/develop/how-midnight-works",
+        "destination": "/category/how-midnight-works",
+        "permanent": true
+      },
+      {
+        "source": "/develop/how-midnight-works/transaction-semantics",
+        "destination": "/concepts/how-midnight-works/semantics",
+        "permanent": true
+      },
+      {
+        "source": "/develop/how-midnight-works/concepts",
+        "destination": "/category/how-midnight-works",
+        "permanent": true
+      },
+      {
         "source": "/develop/how-midnight-works/:path*",
         "destination": "/concepts/how-midnight-works/:path*",
         "permanent": true
@@ -70,8 +85,28 @@
         "permanent": true
       },
       {
+        "source": "/develop/tutorial/using/chrome-ext",
+        "destination": "/getting-started/installation",
+        "permanent": true
+      },
+      {
+        "source": "/develop/tutorial/using/proof-server",
+        "destination": "/guides/run-proof-server",
+        "permanent": true
+      },
+      {
+        "source": "/develop/tutorial/using/faucet",
+        "destination": "/guides/acquire-tokens",
+        "permanent": true
+      },
+      {
+        "source": "/develop/tutorial/using/prereqs",
+        "destination": "/getting-started/installation",
+        "permanent": true
+      },
+      {
         "source": "/develop/tutorial/:path*",
-        "destination": "/tutorials/beginner/:path*",
+        "destination": "/tutorials",
         "permanent": true
       },
       {
@@ -120,8 +155,18 @@
         "permanent": true
       },
       {
+        "source": "/develop/how-to",
+        "destination": "/category/guides",
+        "permanent": true
+      },
+      {
         "source": "/develop/how-to/:path*",
         "destination": "/guides/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/develop/guides",
+        "destination": "/category/guides",
         "permanent": true
       },
       {
@@ -140,6 +185,36 @@
         "permanent": true
       },
       {
+        "source": "/guides/bun-runtime-midnight",
+        "destination": "/how-to/bun-runtime-midnight",
+        "permanent": true
+      },
+      {
+        "source": "/guides/fix-package-repository-access-failures",
+        "destination": "/how-to/fix-package-repository-access-failures",
+        "permanent": true
+      },
+      {
+        "source": "/guides/getting-started",
+        "destination": "/getting-started",
+        "permanent": true
+      },
+      {
+        "source": "/guides/migrate-from-testnet-02-to-preview",
+        "destination": "/category/troubleshoot",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/midnight-api/wallet-api/:path*",
+        "destination": "/sdks/official/wallet-developer-guide",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/midnight-api/wallet-api",
+        "destination": "/sdks/official/wallet-developer-guide",
+        "permanent": true
+      },
+      {
         "source": "/develop/reference/midnight-api/:path*",
         "destination": "/api-reference/:path*",
         "permanent": true
@@ -153,6 +228,11 @@
       {
         "source": "/operate/node-endpoints",
         "destination": "/nodes/node-endpoints",
+        "permanent": true
+      },
+      {
+        "source": "/operate/network-architecture",
+        "destination": "/category/network-architecture",
         "permanent": true
       },
       {
@@ -181,18 +261,28 @@
         "permanent": true
       },
       {
-        "source": "/develop/reference/midnight-api/wallet-api/:path*",
-        "destination": "/sdks/official/wallet-developer-guide",
-        "permanent": true
-      },
-      {
         "source": "/compact/reference/tools/compiler-usage",
         "destination": "/compact/compilation-and-tooling/compiler-usage",
         "permanent": true
       },
       {
+        "source": "/compact/compact-std-library/:path*",
+        "destination": "/compact/standard-library",
+        "permanent": true
+      },
+      {
         "source": "/compact/compact-std-library",
         "destination": "/compact/standard-library",
+        "permanent": true
+      },
+      {
+        "source": "/compact/ledger-adt",
+        "destination": "/compact/reference/ledger-adt",
+        "permanent": true
+      },
+      {
+        "source": "/compact/security",
+        "destination": "/compact/smart-contract-security",
         "permanent": true
       },
       {
@@ -239,6 +329,11 @@
       {
         "source": "/develop/reference/sdk",
         "destination": "/api-reference/midnight-js",
+        "permanent": true
+      },
+      {
+        "source": "/develop/reference/tools/compiler-usage",
+        "destination": "/compact/compilation-and-tooling/compiler-usage",
         "permanent": true
       },
       {
@@ -322,6 +417,11 @@
         "permanent": true
       },
       {
+        "source": "/next/relnotes",
+        "destination": "/relnotes/overview",
+        "permanent": true
+      },
+      {
         "source": "/next/relnotes/:path*",
         "destination": "/relnotes/:path*",
         "permanent": true
@@ -334,6 +434,11 @@
       {
         "source": "/next/tutorials/:path*",
         "destination": "/tutorials/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/next/how-to",
+        "destination": "/category/guides",
         "permanent": true
       },
       {
@@ -372,6 +477,46 @@
         "permanent": true
       },
       {
+        "source": "/docs/develop/getting-help.mdx",
+        "destination": "/troubleshoot/getting-help",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/how-midnight-works/index.mdx",
+        "destination": "/category/how-midnight-works",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/how-midnight-works/smart-contracts.mdx",
+        "destination": "/concepts/how-midnight-works/smart-contracts",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/tutorial/index.mdx",
+        "destination": "/tutorials",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/tutorial/1-using/faucet.mdx",
+        "destination": "/guides/acquire-tokens",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/reference/compact/lang-ref.mdx",
+        "destination": "/compact/reference/compact-reference",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/reference/compact/:path*",
+        "destination": "/compact/:path*",
+        "permanent": true
+      },
+      {
+        "source": "/docs/develop/reference/compact",
+        "destination": "/compact",
+        "permanent": true
+      },
+      {
         "source": "/docs/develop/:path*",
         "destination": "/:path*",
         "permanent": true
@@ -407,6 +552,31 @@
         "permanent": true
       },
       {
+        "source": "/relnotes/faucet/:path*",
+        "destination": "/relnotes/overview",
+        "permanent": true
+      },
+      {
+        "source": "/relnotes/faucet",
+        "destination": "/relnotes/overview",
+        "permanent": true
+      },
+      {
+        "source": "/relnotes/vs-code-extension",
+        "destination": "/relnotes/overview",
+        "permanent": true
+      },
+      {
+        "source": "/relnotes/wallet/wallet-3-6-0-RC17",
+        "destination": "/relnotes/wallet",
+        "permanent": true
+      },
+      {
+        "source": "/relnotes/wallet/wallet-5-0-0",
+        "destination": "/relnotes/wallet",
+        "permanent": true
+      },
+      {
         "source": "/relnotes/lace/:path*",
         "destination": "/relnotes/overview",
         "permanent": true
@@ -414,6 +584,11 @@
       {
         "source": "/tutorials/beginner/counter/:path*",
         "destination": "/tutorials/bboard",
+        "permanent": true
+      },
+      {
+        "source": "/tutorials/beginner/bboard-contract",
+        "destination": "/tutorials/bboard/smart-contract",
         "permanent": true
       },
       {
@@ -572,12 +747,107 @@
         "permanent": true
       },
       {
-        "source": "/api-reference/wallet-api/README.md",
+        "source": "/api-reference/ledger/classes/Input",
+        "destination": "/api-reference/ledger/classes/ZswapInput",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/Output",
+        "destination": "/api-reference/ledger/classes/ZswapOutput",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/Offer",
+        "destination": "/api-reference/ledger/classes/ZswapOffer",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/ContractCallsPrototype",
+        "destination": "/api-reference/ledger/classes/ContractCallPrototype",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/ProofErasedInput",
+        "destination": "/api-reference/ledger/classes/ZswapInput",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/ProofErasedOffer",
+        "destination": "/api-reference/ledger/classes/ZswapOffer",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/ProofErasedTransaction",
+        "destination": "/api-reference/ledger/classes/Transaction",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/ProofErasedAuthorizedMint",
+        "destination": "/api-reference/ledger",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/UnprovenAuthorizedMint",
+        "destination": "/api-reference/ledger",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/UnprovenOffer",
+        "destination": "/api-reference/ledger/classes/ZswapOffer",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/ledger/classes/UnprovenTransient",
+        "destination": "/api-reference/ledger/classes/ZswapTransient",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/dapp-connector/classes/APIError",
+        "destination": "/api-reference/dapp-connector/type-aliases/APIError",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/dapp-connector/classes/:path*",
+        "destination": "/api-reference/dapp-connector",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/dapp-connector/interfaces/:path*",
+        "destination": "/api-reference/dapp-connector",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/dapp-connector/docs/develop/guides/wallet-dev-guide.mdx",
         "destination": "/sdks/official/wallet-developer-guide",
         "permanent": true
       },
       {
-        "source": "/api-reference/wallet-api/globals",
+        "source": "/api-reference/docs/develop/guides/wallet-dev-guide.mdx",
+        "destination": "/sdks/official/wallet-developer-guide",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/midnight-js/@midnight-ntwrk/midnight-js-testing/:path*",
+        "destination": "/api-reference/midnight-js",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/midnight-js/@midnight-ntwrk/midnight-js-testing",
+        "destination": "/api-reference/midnight-js",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/midnight-js/@midnight-ntwrk/midnight-js-types/interfaces/Contract",
+        "destination": "/api-reference/midnight-js/@midnight-ntwrk/midnight-js-types",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/wallet-api/:path*",
+        "destination": "/sdks/official/wallet-developer-guide",
+        "permanent": true
+      },
+      {
+        "source": "/api-reference/wallet-api",
         "destination": "/sdks/official/wallet-developer-guide",
         "permanent": true
       },
@@ -678,11 +948,6 @@
         "permanent": true
       },
       {
-        "source": "/docs/develop/reference/compact/:path*",
-        "destination": "/compact/:path*",
-        "permanent": true
-      },
-      {
         "source": "/compact/writing.mdx",
         "destination": "/compact/reference/writing",
         "permanent": true
@@ -737,11 +1002,6 @@
         "destination": "/compact",
         "permanent": true
       },
-      {
-        "source": "/docs/develop/reference/compact",
-        "destination": "/compact",
-        "permanent": true
-      },
 
       {
         "source": "/learn/what-is-midnight",
@@ -750,11 +1010,6 @@
       },
       {
         "source": "/learn/understanding-midnights-technology",
-        "destination": "/concepts",
-        "permanent": true
-      },
-      {
-        "source": "/develop/how-midnight-works",
         "destination": "/concepts",
         "permanent": true
       },
@@ -779,18 +1034,8 @@
         "permanent": true
       },
       {
-        "source": "/develop/guides",
-        "destination": "/category/guides",
-        "permanent": true
-      },
-      {
         "source": "/develop/reference/midnight-api",
         "destination": "/api-reference",
-        "permanent": true
-      },
-      {
-        "source": "/operate/network-architecture",
-        "destination": "/concepts",
         "permanent": true
       },
       {
@@ -801,11 +1046,6 @@
       {
         "source": "/operate",
         "destination": "/nodes",
-        "permanent": true
-      },
-      {
-        "source": "/develop/reference/midnight-api/wallet-api",
-        "destination": "/sdks/official/wallet-developer-guide",
         "permanent": true
       },
       {
@@ -849,18 +1089,8 @@
         "permanent": true
       },
       {
-        "source": "/next/relnotes",
-        "destination": "/relnotes/overview",
-        "permanent": true
-      },
-      {
         "source": "/next/tutorials",
         "destination": "/tutorials",
-        "permanent": true
-      },
-      {
-        "source": "/next/how-to",
-        "destination": "/category/guides",
         "permanent": true
       },
       {


### PR DESCRIPTION
## Summary

- Fixes all 81 broken redirect chains flagged by Google Search Console
- Updates `vercel.json` redirect entries that pointed to removed or renamed pages
- Ensures redirect chains resolve to valid destination URLs

Replaces #1128 (recreated from upstream branch so deploy preview works).