### PR TITLE
fix: correct llm-documentation meta tag URL to /llms.txt

### DIFF
--- a/docs/overview/index.mdx
+++ b/docs/overview/index.mdx
@@ -8,7 +8,7 @@ displayed_sidebar: sidebar
 ---
 
 <head>
-  <meta name="llm-documentation" content="https://docs.midnight.network/llm.txt" />
+  <meta name="llm-documentation" content="https://docs.midnight.network/llms.txt" />
   <link rel="alternate" type="text/plain" href="/llms.txt" title="LLM Documentation" />
 </head>
 

--- a/main_versioned_docs/version-0.0.0/index.mdx
+++ b/main_versioned_docs/version-0.0.0/index.mdx
@@ -8,7 +8,7 @@ displayed_sidebar: sidebar
 ---
 
 <head>
-  <meta name="llm-documentation" content="https://docs.midnight.network/llm.txt" />
+  <meta name="llm-documentation" content="https://docs.midnight.network/llms.txt" />
   <link rel="alternate" type="text/plain" href="/llms.txt" title="LLM Documentation" />
 </head>
 


### PR DESCRIPTION
## Summary

The `llm-documentation` meta tag on the docs landing page points to `https://docs.midnight.network/llm.txt`, which 404s. The file generated by `@signalwire/docusaurus-plugin-llms-txt` lives at `/llms.txt`, and the `<link rel="alternate">` on the same page already points there correctly. This fixes the meta tag to match.

## Changes

- `docs/overview/index.mdx`: `llm.txt` -> `llms.txt` in the meta tag
- `main_versioned_docs/version-0.0.0/index.mdx`: same fix in the versioned copy

## Testing

- Repo-wide grep confirms no remaining references to `/llm.txt`
- https://docs.midnight.network/llms.txt resolves; `/llm.txt` 404s