### PR TITLE
build(deps): bump actions/checkout from 7.0.0 to 7.0.1

### DIFF
--- a/.github/workflows/apis.yml
+++ b/.github/workflows/apis.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout docs repository specific branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           path: ${{ github.workspace }}
           ref: ${{ github.event.inputs.branch_merge }}

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 
 
       - name: Get changed files
         id: changed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Activate Yarn 4 via Corepack
         run: |

--- a/.github/workflows/light-house-ci.yml
+++ b/.github/workflows/light-house-ci.yml
@@ -32,7 +32,7 @@ jobs:
           export CHROME_PATH=$(which google-chrome)
           echo "Chrome is installed at $CHROME_PATH"
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
 
       - name: Read paths from file and generate full URLs
         id: read-urls

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
 
       - name: Check links
         uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225  #v1.1.2

--- a/.github/workflows/playwright-visual-regression.yml
+++ b/.github/workflows/playwright-visual-regression.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
 
       - name: Enable Corepack (Pre-Setup)
         run: corepack enable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           fetch-depth: 2
       - name: Enable Corepack (Pre-Setup)

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -25,7 +25,7 @@ jobs:
   deploy-prod:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           ref: "main"
       - name: Setup Node.js

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout midnight-docs
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: ${{ github.workspace }}
           ref: ${{ github.event.inputs.branch_merge }}

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -24,7 +24,7 @@ jobs:
       statuses: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  #v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  #v7.0.1
 
       - name: Scan code
         uses: midnightntwrk/upload-sarif-github-action@07dad711370cc5985885ebcf07cb8c9264bc4167

--- a/.github/workflows/sync-release-notes.yml
+++ b/.github/workflows/sync-release-notes.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout midnight-docs
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
 

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:


### PR DESCRIPTION
> AI-assisted (Claude) — this repo has no `bot:ai-assisted` label to apply; flagging the gap.

Supersedes #1165 (dependabot). That PR can never go green: this repo has the new `sha_pinning_required` Actions policy, and with it enabled GitHub creates **no workflow runs at all** for dependabot-authored PRs that modify `.github/workflows/**` — the required `scan` check never reports. Verified across every event type (dependabot recreate, web-flow update-branch, human close/reopen all silent; human workflow-PRs and non-workflow dependabot PRs run fine; midnight-iac with the policy off runs its dependabot workflow bumps normally).

Identical diff to #1165, human-authored so workflows trigger. `3d3c42e5` verified as the real `actions/checkout` v7.0.1 tag commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)