### PR TITLE
test: single-file uses: SHA bump probe (do not merge)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Activate Yarn 4 via Corepack
         run: |


### PR DESCRIPTION
> AI-assisted (Claude); no bot:ai-assisted label exists in this repo.

Diagnostic probe for the sha_pinning_required run-suppression affecting #1165/#1187: bumps one `uses:` SHA in one file. If Actions stays silent here, any PR changing action references is suppressed under the policy. Will be closed after observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)