### PR TITLE
docs: replace retired testnet-02 endpoints in validator runbook

### DIFF
--- a/docs/nodes/_run-a-validator/index.mdx
+++ b/docs/nodes/_run-a-validator/index.mdx
@@ -169,9 +169,7 @@ An existing Cardano relay node can be repurposed for `cardano-db-sync` if the op
 
 ## Public endpoints
 
-Midnight-node uses partner-chains CLI commands which require on an Ogmios connect. While you may run Ogmios locally, we provide a public endpoint for the service.
-
-* [ogmios.testnet-02.midnight.network](https://ogmios.testnet-02.midnight.network)
+Midnight-node uses partner-chains CLI commands which require an Ogmios connect. You can run Ogmios locally — this guide's steps assume the `cardano-ogmios` container from the local Docker Compose setup (see [step 2](./step-2) for the full dependency stack).
 
 ### Network and Security Considerations for Testnet:
 

--- a/docs/nodes/_run-a-validator/step-1.mdx
+++ b/docs/nodes/_run-a-validator/step-1.mdx
@@ -13,7 +13,7 @@ To embark on the path of becoming a Midnight validator, one must either be, or b
 
 | Cardano env. | Status | Midnight env.
 |----------|----------|----------|
-| `preview` | ✅ | `testnet-02` |
+| `preview` | ✅ | `preview` |
 | `preprod` | ❌ | N/A |
 | `mainnet` | ❌ | N/A |
 

--- a/docs/nodes/_run-a-validator/step-3.mdx
+++ b/docs/nodes/_run-a-validator/step-3.mdx
@@ -428,7 +428,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "sidechain_getStatus",
       "params": [INSERT_EPOCH],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 Example output:
@@ -439,7 +439,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "sidechain_getStatus",
       "params": [],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   297  100   193  100   104    395    213 --:--:-- --:--:-- --:--:--   608
@@ -469,7 +469,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "systemParameters_getAriadneParameters",
       "params": [697],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 Look for your registration under `"candidateRegistrations": {)`. Ensure you see your Partner-chain keys in the registration and  `"isValid": true`
@@ -516,7 +516,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "systemParameters_getAriadneParameters",
       "params": [INSERT_EPOCH],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 You should see your candidate is no longer on the list.


### PR DESCRIPTION
## What

Replaces the retired `testnet-02` endpoints in the validator runbook (`docs/nodes/_run-a-validator/`) with the current Preview equivalents, per #1172.

- **step-3.mdx** — four `curl` examples pointed at `rpc.testnet-02.midnight.network` (NXDOMAIN since the Preview transition); now use `rpc.preview.midnight.network`.
- **step-1.mdx** — the supported-environments table mapped Cardano `preview` to Midnight `testnet-02`; now maps to the Midnight `preview` environment.
- **index.mdx** — the "Public endpoints" section linked `ogmios.testnet-02.midnight.network`, which no longer resolves and has no Preview equivalent. The guide's own Docker Compose stack (step 2) runs Ogmios locally via the `cardano-ogmios` container, so the section now points there instead of advertising a dead public endpoint.

## Why

`testnet-02` was retired on 2026-01-27; `rpc.testnet-02.midnight.network` and `ogmios.testnet-02.midnight.network` return NXDOMAIN (verified against public resolvers). Every new validator following these steps hits a dead endpoint first. The migration guide already documents the testnet-02 → Preview transition; this removes the stale references around it.

## Scope notes

- Historical release notes (`docs/relnotes/`) and the versioned docs (`main_versioned_docs/`) keep their `testnet-02` mentions intentionally — they document what was true at the time.
- `step-3.mdx` line 50 still references `midnight-node-docker`'s `envs/testnet-02/pc-chain-config.json` because that external repo still ships that path; it was left untouched.
