### PR TITLE
fix: add mn-security + mn-sre as owners of package.json and yarn.lock

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,8 @@
 
 /docs/compact/ @midnightntwrk/mn-codeowners-compact @midnightntwrk/mn-codeowners-docs
 /.github/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
+package.json @midnightntwrk/mn-techwriting @midnightntwrk/mn-devrel @midnightntwrk/mn-codeowners-docs @midnightntwrk/mn-security @midnightntwrk/mn-sre
+yarn.lock @midnightntwrk/mn-techwriting @midnightntwrk/mn-devrel @midnightntwrk/mn-codeowners-docs @midnightntwrk/mn-security @midnightntwrk/mn-sre
 CODE_OF_CONDUCT.md @midnightntwrk/mn-security @midnightntwrk/mn-sre @midnightntwrk/mn-codeowners-docs
 CODEOWNERS @midnightntwrk/mn-security @midnightntwrk/mn-sre
 CONTRIBUTING.md @midnightntwrk/mn-security @midnightntwrk/mn-sre @midnightntwrk/mn-codeowners-docs


### PR DESCRIPTION
> AI-assisted (Claude); no bot:ai-assisted label exists in this repo.

Follow-up to #1216 (this commit was pushed to that branch just after it merged, so it never landed). Dependency manifests and the lockfile are supply-chain surface; mn-security and mn-sre can now satisfy code-owner review on them alongside the existing docs owners. With #1216's `/.github/` rule now in main, this PR is SRE-approvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)