### PR TITLE
Align tokens tutorial pinned versions with the compatibility matrix

### DIFF
--- a/docs/tokens/unshielded-token.mdx
+++ b/docs/tokens/unshielded-token.mdx
@@ -110,7 +110,7 @@ Because midnight-local-dev already runs a proof server, you do not start one sep
 You can run the exact same code against the public **Preprod** network instead of local. In that case you do not run midnight-local-dev. Start a standalone proof server in its own terminal:
 
 ```bash
-docker run -p 6300:6300 midnightntwrk/proof-server:8.0.3 midnight-proof-server -v
+docker run -p 6300:6300 midnightntwrk/proof-server:8.1.0 midnight-proof-server -v
 ```
 
 and fund your own wallet at the Preprod faucet (covered in [Run it](#run-it)). The flow is identical; it just takes a couple of minutes more than local.
@@ -161,8 +161,6 @@ pragma language_version 0.23;
 
 import CompactStandardLibrary;
 ```
-
-The `wallet-sdk` version matters here. Pin it to 1.0.0. A newer minor pulls in a ledger version that the network rejects when you deploy a contract.
 
 `import CompactStandardLibrary` brings in the token primitives you use below, like `mintUnshieldedToken`, `sendUnshielded`, and `unshieldedBalanceGte`.
 
@@ -286,7 +284,7 @@ Add the wallet SDK, the supporting libraries the harness imports, and tsx to run
 
 ```bash
 npm install \
-  @midnight-ntwrk/wallet-sdk@1.0.0 \
+  @midnight-ntwrk/wallet-sdk@1.2.0 \
   @midnight-ntwrk/testkit-js@4.1.1 \
   @midnight-ntwrk/midnight-js-protocol@4.1.1 \
   @midnight-ntwrk/midnight-js-network-id@4.1.1 \
@@ -295,7 +293,7 @@ npm install \
 npm install --save-dev tsx@4.22.4
 ```
 
-The `wallet-sdk` version matters here. Pin it to 1.0.0, because a newer minor pulls in a ledger version that the network rejects when you deploy a contract.
+The `wallet-sdk` version matters here. Pin it exactly to 1.2.0, the version listed in the [compatibility matrix](/relnotes/support-matrix). npm's `latest` dist-tag still points at 1.1.0, so installing without an exact version would silently resolve to an older release.
 
 For reference, your `package.json` dependencies should now read:
 
@@ -312,7 +310,7 @@ For reference, your `package.json` dependencies should now read:
     "@midnight-ntwrk/midnight-js-types": "4.1.1",
     "@midnight-ntwrk/midnight-js-utils": "4.1.1",
     "@midnight-ntwrk/testkit-js": "4.1.1",
-    "@midnight-ntwrk/wallet-sdk": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk": "1.2.0",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
     "rxjs": "7.8.2",


### PR DESCRIPTION
## Summary

Updates the hard-pinned versions in the unshielded token tutorial to match the [compatibility matrix](https://docs.midnight.network/relnotes/support-matrix):

- `@midnight-ntwrk/wallet-sdk` pin bumped from `1.0.0` to `1.2.0` in the install command, the reference `package.json`, and the surrounding prose. The exact pin is still required: npm's `latest` dist-tag points at `1.1.0`, so an unpinned install silently resolves to an older release.
- Standalone proof server image bumped from `midnightntwrk/proof-server:8.0.3` to `8.1.0`.
- Removed a misplaced duplicate of the wallet-sdk pin note that sat in the Compact language section.

The shielded token tutorial reuses this setup and needed no changes; its only version reference (compactc 0.31.1) already matches the matrix.