### PR TITLE
docs: fix two non-compiling snippets in keeping-data-private

### DIFF
--- a/docs/concepts/how-midnight-works/keeping-data-private.mdx
+++ b/docs/concepts/how-midnight-works/keeping-data-private.mdx
@@ -147,7 +147,7 @@ export circuit insert(item: Field): [] {
 
 export circuit check(item: Field): [] {
   const path = findItem(item);
-  assert(items.checkRoot(merkleTreePathRoot<10, Field>(path.value)), "path must be valid");
+  assert(items.checkRoot(merkleTreePathRoot<10, Field>(path)), "path must be valid");
 }
 ```
 
@@ -209,7 +209,7 @@ export circuit increment(): [] {
   assert(authorizedCommitments.checkRoot(merkleTreePathRoot<10, Bytes<32>>(authPath)),
     "not authorized");
   const nul = nullifier(sk);
-  assert !authorizedNullifiers.member(nul) "already incremented";
+  assert(!authorizedNullifiers.member(nul), "already incremented");
   authorizedNullifiers.insert(disclose(nul));
   restrictedCounter.increment(1);
 }


### PR DESCRIPTION
Two code examples in `docs/concepts/how-midnight-works/keeping-data-private.mdx` do not compile as written:

**1. `MerkleTreePath` has no `.value` field.**
`merkleTreePathRoot<#n, T>(path: MerkleTreePath<n, T>)` takes the path itself, and the struct only declares `leaf` and `path`. The second example in the same page already passes the path directly (`merkleTreePathRoot<10, Bytes<32>>(authPath)`), so this looks like a leftover.

**2. Pre-0.16 `assert` syntax.**
`assert !cond "msg";` predates the change to `assert(cond, "msg")`. The same code block already uses the current form a few lines above, so one of the two would fail to compile. This is the only occurrence left under `docs/`.

This page is the canonical explanation of the commitment/nullifier pattern, so the examples are likely to be copied as-is.