### PR TITLE
docs: fix dead testnet-02 RPC endpoint in run-a-validator guide

### DIFF
--- a/docs/nodes/_run-a-validator/step-3.mdx
+++ b/docs/nodes/_run-a-validator/step-3.mdx
@@ -428,7 +428,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "sidechain_getStatus",
       "params": [INSERT_EPOCH],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 Example output:
@@ -439,7 +439,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "sidechain_getStatus",
       "params": [],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100   297  100   193  100   104    395    213 --:--:-- --:--:-- --:--:--   608
@@ -469,7 +469,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "systemParameters_getAriadneParameters",
       "params": [697],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 Look for your registration under `"candidateRegistrations": {)`. Ensure you see your Partner-chain keys in the registration and  `"isValid": true`
@@ -516,7 +516,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "systemParameters_getAriadneParameters",
       "params": [INSERT_EPOCH],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 You should see your candidate is no longer on the list.

--- a/docs/nodes/_run-a-validator/step-3.mdx
+++ b/docs/nodes/_run-a-validator/step-3.mdx
@@ -426,7 +426,7 @@ There's a known issue with register3 querying the Postgres database, but don't w
 curl -L -X POST -H "Content-Type: application/json" -d '{
       "jsonrpc": "2.0",
       "method": "sidechain_getStatus",
-      "params": [INSERT_EPOCH],
+      "params": [],
       "id": 1
     }' https://rpc.preview.midnight.network | jq
 ```


### PR DESCRIPTION
Fixes #1172.

Four example commands in the run-a-validator guide pointed at `rpc.testnet-02.midnight.network`, which was retired with testnet-02 and no longer resolves (NXDOMAIN). This PR updates them to the current live `rpc.preview.midnight.network` endpoint, matching the Preview onboarding guide.

Also, per review feedback: the first `sidechain_getStatus` example passed `"params": [INSERT_EPOCH]`, but the method accepts no parameters — changed to `"params": []` (the `systemParameters_getAriadneParameters` examples keep their epoch parameter, which that method does take).

**Verification:**
- `host rpc.testnet-02.midnight.network` → NXDOMAIN
- `host rpc.preview.midnight.network` → resolves (3 A records)
- Docs-only change, single file: `docs/nodes/_run-a-validator/step-3.mdx`

*Apologies for the earlier PR description — it was pasted from an unrelated project by mistake and described work that is not in this repo. This body now describes the actual diff.*
