### PR TITLE
Add compact-js v2.5.3 release notes

### DIFF
--- a/docs/relnotes/compact-js/compact-js-2-5-3.mdx
+++ b/docs/relnotes/compact-js/compact-js-2-5-3.mdx
@@ -1,0 +1,17 @@
+## What's Changed
+* Update version from 2.5.1 to 2.5.2 in CHANGELOG by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/189
+* chore/version bump and release version bump by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/190
+* chore/disable broken run by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/191
+* chore(deps): update dependency tar to v7.5.16 [security] by @renovate[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/202
+* chore: Bump turbo from 2.9.16 to 2.9.18 in /platform-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/193
+* chore: Bump @commitlint/cli from 19.8.1 to 21.0.2 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/192
+* chore: Bump @effect/printer-ansi from 0.48.0 to 0.49.0 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/197
+* chore: Bump @effect/platform-node from 0.106.0 to 0.107.0 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/195
+* chore: Bump @effect/sql from 0.50.0 to 0.51.1 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/199
+* chore: Bump eslint-plugin-simple-import-sort from 12.1.1 to 13.0.0 in /platform-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/200
+* Chore/fix cjs exports by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/204
+* chore/update-version-bump by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/205
+* chore/fix version bump one more by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/206
+
+
+**Full Changelog**: https://github.com/midnightntwrk/midnight-sdk/compare/compact-js-v2.5.2...compact-js-v2.5.3

--- a/docs/relnotes/compact-js/compact-js-2-5-3.mdx
+++ b/docs/relnotes/compact-js/compact-js-2-5-3.mdx
@@ -1,17 +1,68 @@
-## What's Changed
-* Update version from 2.5.1 to 2.5.2 in CHANGELOG by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/189
-* chore/version bump and release version bump by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/190
-* chore/disable broken run by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/191
-* chore(deps): update dependency tar to v7.5.16 [security] by @renovate[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/202
-* chore: Bump turbo from 2.9.16 to 2.9.18 in /platform-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/193
-* chore: Bump @commitlint/cli from 19.8.1 to 21.0.2 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/192
-* chore: Bump @effect/printer-ansi from 0.48.0 to 0.49.0 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/197
-* chore: Bump @effect/platform-node from 0.106.0 to 0.107.0 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/195
-* chore: Bump @effect/sql from 0.50.0 to 0.51.1 in /compact-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/199
-* chore: Bump eslint-plugin-simple-import-sort from 12.1.1 to 13.0.0 in /platform-js by @dependabot[bot] in https://github.com/midnightntwrk/midnight-sdk/pull/200
-* Chore/fix cjs exports by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/204
-* chore/update-version-bump by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/205
-* chore/fix version bump one more by @VanessaPC in https://github.com/midnightntwrk/midnight-sdk/pull/206
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Compact.js 2.5.3 release notes
+description: Provides a TypeScript-based runtime for compiled Compact smart contracts.
+displayed_sidebar: sidebar
+toc_max_heading_level: 2
+---
 
+- **Version**: 2.5.3
+- **Date**: 9 July 2026
 
-**Full Changelog**: https://github.com/midnightntwrk/midnight-sdk/compare/compact-js-v2.5.2...compact-js-v2.5.3
+---
+
+## High-level summary
+
+Compact.js provides a TypeScript-based execution environment for smart contracts compiled with the [Compact](../../compact) language.
+
+Version 2.5.3 is a maintenance release and the first version published to npm from the migrated `midnightntwrk/midnight-sdk` repository. It fixes the CommonJS exports configuration of the package, applies a security update to the `tar` dependency, and refreshes development dependencies and release automation.
+
+Versions 2.5.1 and 2.5.2 were version-alignment steps during the repository migration: 2.5.1 was published to npm without a GitHub release, and 2.5.2 was tagged but never published to npm. Version 2.5.3 supersedes both.
+
+---
+
+## Audience
+
+This release is relevant for developers who build tools or frameworks that deploy and interact with contracts on the Midnight blockchain.
+
+---
+
+## New features
+
+This release introduces no new features.
+
+---
+
+## Improvements
+
+- Fixed the CommonJS exports configuration of the package, so consumers using `require` resolve the package correctly.
+- Security update: bumped the `tar` dependency to 7.5.16.
+- Updated development dependencies, including turbo, commitlint, the `@effect` packages, and lint tooling.
+- Fixed the version-bump and release automation in the migrated repository.
+
+---
+
+## Deprecations
+
+No deprecations in this release.
+
+---
+
+## Breaking changes
+
+No breaking changes in this release.
+
+---
+
+## Important notes
+
+The changelog attached to the GitHub release is generated cumulatively and repeats feature entries that shipped in earlier 2.5.x versions, such as `LedgerParameters` support on circuit execution. See the [2.5.0 release notes](/relnotes/compact-js/compact-js-2-5-0) for those changes.
+
+---
+
+## Links and references
+
+- [GitHub release: compact-js-v2.5.3](https://github.com/midnightntwrk/midnight-sdk/releases/tag/compact-js-v2.5.3)
+- [`@midnight-ntwrk/compact-js` on npm](https://www.npmjs.com/package/@midnight-ntwrk/compact-js/v/2.5.3)
+- [Compact.js 2.5.0 release notes](/relnotes/compact-js/compact-js-2-5-0)

--- a/src/components/DynamicListCompactJS.js
+++ b/src/components/DynamicListCompactJS.js
@@ -19,10 +19,18 @@ const releases = [
   {
     version: '2.5.3',
     status: 'LATEST',
-    date: '27 August 2026',
-    summary: 'Summary of Release 2.5.3',
-    details: [],
-    artifacts: [],
+    date: '9 July 2026',
+    summary: 'Maintenance release from the migrated midnight-sdk repository with a CommonJS exports fix.',
+    details: [
+      'Fixed the CommonJS exports configuration of the package.',
+      'Security update: bumped the `tar` dependency to 7.5.16.',
+      'Updated development dependencies and release automation.',
+      'First version published to npm from the migrated `midnightntwrk/midnight-sdk` repository; supersedes the 2.5.1 and 2.5.2 alignment versions.',
+    ],
+    artifacts: [
+      { name: 'NPM Package', url: 'https://www.npmjs.com/package/@midnight-ntwrk/compact-js/v/2.5.3' },
+      { name: 'GitHub release', url: 'https://github.com/midnightntwrk/midnight-sdk/releases/tag/compact-js-v2.5.3' },
+    ],
     link: '/relnotes/compact-js/compact-js-2-5-3',
   },
   {

--- a/src/components/DynamicListCompactJS.js
+++ b/src/components/DynamicListCompactJS.js
@@ -17,8 +17,17 @@ import { useLocation } from '@docusaurus/router';
 
 const releases = [
   {
-    version: '2.5.0',
+    version: '2.5.3',
     status: 'LATEST',
+    date: '27 August 2026',
+    summary: 'Summary of Release 2.5.3',
+    details: [],
+    artifacts: [],
+    link: '/relnotes/compact-js/compact-js-2-5-3',
+  },
+  {
+    version: '2.5.0',
+    status: 'SUPPORTED',
     date: '20 March 2026',
     summary: 'Compatibility and tooling update for Compact.js.',
     details: [


### PR DESCRIPTION
## Summary

Adds the Compact.js 2.5.3 release notes (the docs stopped at 2.5.0) and fills in the DynamicList entry.

While preparing this I found the 2.5.1/2.5.2 lineage is messy: 2.5.1 went to npm with no GitHub release, 2.5.2 was tagged in the migrated `midnightntwrk/midnight-sdk` repo but never published to npm, and the release changelog sections are cumulative copies of each other. So the page documents 2.5.3 as the maintenance release that supersedes both (CommonJS exports fix, `tar` security bump, dependency and release automation updates) and says so explicitly, rather than inventing separate 2.5.1/2.5.2 pages.

## Notes for review

- The support matrix references `compact-js-2.5.1`, which exists on npm but not as a git tag. If the matrix should point at 2.5.3, that is a follow-up with SME confirmation.
