### PR TITLE
Add dapp-connector-api v4.0.1 release notes

### DIFF
--- a/docs/relnotes/dapp-connector-api/dapp-connector-api-4-0-1.mdx
+++ b/docs/relnotes/dapp-connector-api/dapp-connector-api-4-0-1.mdx
@@ -1,0 +1,5 @@
+## What's Changed
+* Add missing "payFees" options to transacting methods by @kapke in https://github.com/midnightntwrk/midnight-dapp-connector-api/pull/24
+
+
+**Full Changelog**: https://github.com/midnightntwrk/midnight-dapp-connector-api/compare/v4.0.0...v4.0.1

--- a/docs/relnotes/dapp-connector-api/dapp-connector-api-4-0-1.mdx
+++ b/docs/relnotes/dapp-connector-api/dapp-connector-api-4-0-1.mdx
@@ -1,5 +1,64 @@
-## What's Changed
-* Add missing "payFees" options to transacting methods by @kapke in https://github.com/midnightntwrk/midnight-dapp-connector-api/pull/24
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: DApp Connector API v4.0.1 release notes
+description: This API provides a comprehensive interface for the DApp - Wallet connection, defining the structure of the data and operations available.
+displayed_sidebar: sidebar
+---
 
+* **Version**: v4.0.1
+* **Date**: 17 February 2026
 
-**Full Changelog**: https://github.com/midnightntwrk/midnight-dapp-connector-api/compare/v4.0.0...v4.0.1
+---
+
+## High-level summary
+
+DApp Connector API v4.0.1 is a patch release on the v4.0.0 redesign. It closes a gap in the transaction method types: the option to disable fee payment was only available on `makeIntent`, and this release adds the same `payFees` option to all transacting methods in a backwards-compatible way. All transacting methods now share a uniform API.
+
+Disabling fee payment lets a DApp construct a transaction whose fees are paid elsewhere, for example by a sponsor wallet running in a separate, dedicated service.
+
+---
+
+## Audience
+
+This release note is relevant for developers who:
+
+- Use `@midnight-ntwrk/dapp-connector-api` in their DApps.
+- Build sponsored-fee flows where a wallet other than the connected one pays transaction fees.
+- Maintain wallet implementations compatible with the DApp Connector API.
+
+---
+
+## What changed (Summary of updates)
+
+- Added the `payFees` option to all transacting methods. Previously only `makeIntent` exposed it.
+- Documented the motivation for the option in the API specification.
+
+---
+
+## New features
+
+### `payFees` option on all transacting methods
+
+Every transacting method now accepts the `payFees` option that `makeIntent` already had, so you can disable fee payment on any transaction the connector builds. The change is backwards-compatible: omitting the option keeps the existing behavior of paying fees from the connected wallet.
+
+---
+
+## Breaking changes
+
+No breaking changes in this release.
+
+---
+
+## Known issues
+
+No new known issues in this release.
+
+---
+
+## Links and references
+
+- [GitHub release: v4.0.1](https://github.com/midnightntwrk/midnight-dapp-connector-api/releases/tag/v4.0.1)
+- [`@midnight-ntwrk/dapp-connector-api` on npm](https://www.npmjs.com/package/@midnight-ntwrk/dapp-connector-api)
+- [Full changelog: v4.0.0 to v4.0.1](https://github.com/midnightntwrk/midnight-dapp-connector-api/compare/v4.0.0...v4.0.1)
+- [DApp Connector API v4.0.0 release notes](/relnotes/dapp-connector-api/dapp-connector-api-4-0-0)

--- a/src/components/DynamicListDappConnectorAPI.js
+++ b/src/components/DynamicListDappConnectorAPI.js
@@ -19,10 +19,18 @@ const releases = [
   {
     version: '4.0.1',
     status: 'LATEST',
-    date: '27 August 2026',
-    summary: 'Summary of Release 4.0.1',
-    details: [],
-    artifacts: [],
+    date: '17 February 2026',
+    summary: 'Patch release adding the `payFees` option to all transacting methods for sponsored-fee flows',
+    details: [
+      'All transacting methods now accept the `payFees` option that was previously only available on `makeIntent`.',
+      'Disabling fee payment supports sponsored-fee flows where a separate wallet pays transaction fees.',
+      'Backwards-compatible: omitting the option keeps the existing fee payment behavior.',
+      'The motivation for the option is documented in the API specification.',
+    ],
+    artifacts: [
+      { name: 'NPM package', url: 'https://www.npmjs.com/package/@midnight-ntwrk/dapp-connector-api' },
+      { name: 'GitHub release', url: 'https://github.com/midnightntwrk/midnight-dapp-connector-api/releases/tag/v4.0.1' },
+    ],
     link: '/relnotes/dapp-connector-api/dapp-connector-api-4-0-1',
   },
   {

--- a/src/components/DynamicListDappConnectorAPI.js
+++ b/src/components/DynamicListDappConnectorAPI.js
@@ -17,8 +17,17 @@ import { useLocation } from '@docusaurus/router';
 
 const releases = [
   {
-    version: '4.0.0',
+    version: '4.0.1',
     status: 'LATEST',
+    date: '27 August 2026',
+    summary: 'Summary of Release 4.0.1',
+    details: [],
+    artifacts: [],
+    link: '/relnotes/dapp-connector-api/dapp-connector-api-4-0-1',
+  },
+  {
+    version: '4.0.0',
+    status: 'SUPPORTED',
     date: '28 January 2026',
     summary: 'Summary of v4.0.0',
     details: [


### PR DESCRIPTION
## Summary

Adds the DApp Connector API v4.0.1 release notes, undocumented since February even though the support matrix already lists 4.0.1. Single change: the `payFees` option, previously only on `makeIntent`, is now available on all transacting methods (backwards-compatible), which enables sponsored-fee flows where a separate wallet pays fees.

No matrix change needed: it already shows 4.0.1.
