### PR TITLE
Add Compact developer tools 0.5.0, 0.5.1, and 0.5.2 release notes

### DIFF
--- a/docs/relnotes/compact-tools/compact-tools-0-5-0.mdx
+++ b/docs/relnotes/compact-tools/compact-tools-0-5-0.mdx
@@ -1,0 +1,42 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Compact developer tools 0.5.0
+displayed_sidebar: sidebar
+---
+
+## Compact developer tools 0.5.0 release notes
+
+Compact developer tools (devtools) 0.5.0 ships a pair of usability improvements: subcommands can now be abbreviated, and the `update` subcommand accepts partial version numbers.
+
+If you have an existing devtools installation, you can update it with the command `compact self update`.
+
+If you do not have an existing devtools installation, you can install version 0.5.0 using the shell command shown on [the release page](https://github.com/midnightntwrk/compact/releases/tag/compact-v0.5.0).
+
+## New features
+
+### Subcommand abbreviations
+
+The `compact` CLI now accepts abbreviations for its subcommands, for example `compact up` for `update`, `compact c` for `compile`, and `compact fmt` for `format`.
+
+Most subcommands have official aliases, like `fmt` for `format` and `fx` for `fixup`. You can see these listed in the help text available through `compact help` or `compact --help`.
+
+In addition, most subcommands accept any unambiguous prefix, so `compact c`, `compact co`, and `compact com` all work for `compile`. Where a prefix is ambiguous, the tool makes a choice: `compact c` runs `compile`, not `clean`.
+
+This feature was contributed by GitHub user `rvcas`.
+
+### Partial version numbers
+
+The `update` subcommand now accepts partial version numbers. For example, `compact update 0.30` with the patch number omitted updates to the latest 0.30.x toolchain, so you do not need to know how many patch versions exist to get the newest one.
+
+Likewise, `compact update 0` updates to the latest 0.x.y version. This becomes more useful after Compact 1.0, when `compact up 1` will keep you on the latest patched version of Compact 1.
+
+Parts of this feature were contributed by GitHub user `adamreynolds-io`.
+
+## Breaking changes
+
+None.
+
+## Known issues
+
+- The zkir tool crashes with `SIGILL` when the x64 binaries run under emulation in ARM Docker environments, because no aarch64 Linux build is available in this release ([issue #220](https://github.com/LFDT-Minokawa/compact/issues/220)). Fixed in [devtools 0.5.1](/relnotes/compact-tools/compact-tools-0-5-1), which adds native ARM64 Linux binaries.

--- a/docs/relnotes/compact-tools/compact-tools-0-5-0.mdx
+++ b/docs/relnotes/compact-tools/compact-tools-0-5-0.mdx
@@ -2,12 +2,13 @@
 SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 title: Compact developer tools 0.5.0
+description: The Compact developer tools provide the compact CLI for installing toolchains and compiling, formatting, and fixing up Compact smart contracts.
 displayed_sidebar: sidebar
 ---
 
 ## Compact developer tools 0.5.0 release notes
 
-Compact developer tools (devtools) 0.5.0 ships a pair of usability improvements: subcommands can now be abbreviated, and the `update` subcommand accepts partial version numbers.
+Compact developer tools (devtools) 0.5.0 ships a pair of usability improvements: you can now abbreviate subcommands, and the `update` subcommand accepts partial version numbers.
 
 If you have an existing devtools installation, you can update it with the command `compact self update`.
 
@@ -23,7 +24,7 @@ Most subcommands have official aliases, like `fmt` for `format` and `fx` for `fi
 
 In addition, most subcommands accept any unambiguous prefix, so `compact c`, `compact co`, and `compact com` all work for `compile`. Where a prefix is ambiguous, the tool makes a choice: `compact c` runs `compile`, not `clean`.
 
-This feature was contributed by GitHub user `rvcas`.
+GitHub user `rvcas` contributed this feature.
 
 ### Partial version numbers
 
@@ -31,7 +32,7 @@ The `update` subcommand now accepts partial version numbers. For example, `compa
 
 Likewise, `compact update 0` updates to the latest 0.x.y version. This becomes more useful after Compact 1.0, when `compact up 1` will keep you on the latest patched version of Compact 1.
 
-Parts of this feature were contributed by GitHub user `adamreynolds-io`.
+GitHub user `adamreynolds-io` contributed parts of this feature.
 
 ## Breaking changes
 

--- a/docs/relnotes/compact-tools/compact-tools-0-5-1.mdx
+++ b/docs/relnotes/compact-tools/compact-tools-0-5-1.mdx
@@ -1,0 +1,30 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Compact developer tools 0.5.1
+displayed_sidebar: sidebar
+---
+
+## Compact developer tools 0.5.1 release notes
+
+Compact developer tools (devtools) 0.5.1 adds native ARM64 Linux prebuilt binaries (`aarch64-unknown-linux-musl`) to the release artifacts. ARM Docker environments, such as containers on Apple Silicon hosts, no longer need to emulate the x64 binaries, which crashed the zkir tool with `SIGILL` ([issue #220](https://github.com/LFDT-Minokawa/compact/issues/220)).
+
+There are no functional changes to the CLI itself in this release.
+
+If you have an existing devtools installation, you can update it with the command `compact self update`.
+
+If you do not have an existing devtools installation, you can install version 0.5.1 using the shell command shown on [the release page](https://github.com/midnightntwrk/compact/releases/tag/compact-v0.5.1).
+
+## New features
+
+### Native ARM64 Linux binaries
+
+The release artifacts now include an `aarch64-unknown-linux-musl` build alongside the existing Apple Silicon macOS, Intel macOS, and x64 MUSL Linux builds. The installer script picks the right build for your platform automatically.
+
+## Breaking changes
+
+None.
+
+## Known issues
+
+None.

--- a/docs/relnotes/compact-tools/compact-tools-0-5-1.mdx
+++ b/docs/relnotes/compact-tools/compact-tools-0-5-1.mdx
@@ -2,6 +2,7 @@
 SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 title: Compact developer tools 0.5.1
+description: The Compact developer tools provide the compact CLI for installing toolchains and compiling, formatting, and fixing up Compact smart contracts.
 displayed_sidebar: sidebar
 ---
 

--- a/docs/relnotes/compact-tools/compact-tools-0-5-2.mdx
+++ b/docs/relnotes/compact-tools/compact-tools-0-5-2.mdx
@@ -2,6 +2,7 @@
 SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 title: Compact developer tools 0.5.2
+description: The Compact developer tools provide the compact CLI for installing toolchains and compiling, formatting, and fixing up Compact smart contracts.
 displayed_sidebar: sidebar
 ---
 

--- a/docs/relnotes/compact-tools/compact-tools-0-5-2.mdx
+++ b/docs/relnotes/compact-tools/compact-tools-0-5-2.mdx
@@ -1,0 +1,28 @@
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Compact developer tools 0.5.2
+displayed_sidebar: sidebar
+---
+
+## Compact developer tools 0.5.2 release notes
+
+Compact developer tools (devtools) 0.5.2 is a small maintenance release. Its user-facing change is that `compact compile --help` now forwards to the underlying compiler, so the help output shows the full set of compiler options for your selected toolchain.
+
+If you have an existing devtools installation, you can update it with the command `compact self update`.
+
+If you do not have an existing devtools installation, you can install version 0.5.2 using the shell command shown on [the release page](https://github.com/midnightntwrk/compact/releases/tag/compact-v0.5.2).
+
+## Improvements
+
+### `compact compile --help` shows the full compiler help
+
+Previously, `compact compile --help` showed only the devtools' own options and omitted compiler flags such as `--feature-zkir-v3`. The command now forwards to the underlying `compactc` for the selected toolchain version, so the help output lists every flag the compiler accepts ([issue #648](https://github.com/LFDT-Minokawa/compact/issues/648)).
+
+## Breaking changes
+
+None.
+
+## Known issues
+
+None.

--- a/src/components/DynamicListCompactTools.js
+++ b/src/components/DynamicListCompactTools.js
@@ -17,8 +17,52 @@ import { useLocation } from '@docusaurus/router';
 
 const releases = [
   {
-    version: '0.4.0',
+    version: '0.5.2',
     status: 'LATEST',
+    date: '18 August 2026',
+    summary: 'Maintenance release: compact compile --help shows the full compiler help.',
+    details: [
+      '`compact compile --help` now forwards to the underlying `compactc`, so the help output lists every flag the selected compiler accepts, including `--feature-zkir-v3`.',
+      'Update an existing installation with `compact self update`.',
+    ],
+    artifacts: [
+      { name: 'Compact developer tools', url: 'https://github.com/midnightntwrk/compact/releases/tag/compact-v0.5.2' }
+    ],
+    link: '/relnotes/compact-tools/compact-tools-0-5-2',
+  },
+  {
+    version: '0.5.1',
+    status: 'SUPPORTED',
+    date: '25 March 2026',
+    summary: 'Adds native ARM64 Linux binaries, fixing the zkir SIGILL crash in ARM Docker environments.',
+    details: [
+      'Release artifacts now include an `aarch64-unknown-linux-musl` build, so ARM Docker environments no longer emulate the x64 binaries.',
+      'Fixes the zkir `SIGILL` crash reported when running under emulation on ARM hosts.',
+      'No functional changes to the CLI itself.',
+    ],
+    artifacts: [
+      { name: 'Compact developer tools', url: 'https://github.com/midnightntwrk/compact/releases/tag/compact-v0.5.1' }
+    ],
+    link: '/relnotes/compact-tools/compact-tools-0-5-1',
+  },
+  {
+    version: '0.5.0',
+    status: 'SUPPORTED',
+    date: '17 March 2026',
+    summary: 'Usability release: subcommand abbreviations and partial version numbers for update.',
+    details: [
+      'Subcommands accept official aliases such as `fmt` for `format` and `fx` for `fixup`, plus any unambiguous prefix.',
+      '`compact update` accepts partial version numbers, so `compact update 0.30` installs the latest 0.30.x toolchain.',
+      'Known issue: no aarch64 Linux build, so zkir crashes with `SIGILL` in ARM Docker environments; fixed in 0.5.1.',
+    ],
+    artifacts: [
+      { name: 'Compact developer tools', url: 'https://github.com/midnightntwrk/compact/releases/tag/compact-v0.5.0' }
+    ],
+    link: '/relnotes/compact-tools/compact-tools-0-5-0',
+  },
+  {
+    version: '0.4.0',
+    status: 'SUPPORTED',
     date: '21 January 2026',
     summary: 'Summary of Release 0.4.0',
     details: [


### PR DESCRIPTION
## Summary

Backfills the three undocumented Compact devtools releases. The docs stopped at 0.4.0 while upstream is at 0.5.2 (released 18 August).

- **0.5.0** (17 March): subcommand abbreviations and partial version numbers for `compact update`. The release page for 0.5.0 itself has no notes; the prose was published inside the 0.5.1 release body, which is where these details come from.
- **0.5.1** (25 March): adds native ARM64 Linux (`aarch64-unknown-linux-musl`) binaries, closing LFDT-Minokawa/compact#220 (zkir `SIGILL` under ARM Docker emulation). Commit history between the tags shows no other devtools changes.
- **0.5.2** (18 August): `compact compile --help` now forwards to the underlying `compactc` (LFDT-Minokawa/compact#648), so compiler flags like `--feature-zkir-v3` appear in the help output.

`DynamicListCompactTools.js` gains the three entries with 0.5.2 as LATEST; 0.4.0 is demoted to SUPPORTED.

## Notes for review

- The support matrix currently lists devtools `compact-0.5.1`. I have not touched the matrix: whether 0.5.2 is the tested version for the networks is an SME call.
- compact-tools is not in the `sync-release-notes.yml` component list, so this was done manually.