### PR TITLE
fix: move kapa

### DIFF
--- a/docs/ai-integration/kapa-mcp-server.mdx
+++ b/docs/ai-integration/kapa-mcp-server.mdx
@@ -1,11 +1,10 @@
 ---
 SPDX-License-Identifier: Apache-2.0
 copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
-slug: kapa-mcp-server
 title: Kapa MCP server
 description: The Kapa MCP server gives AI coding assistants documentation-grounded answers about Midnight directly inside your editor.
 tags: [mcp, ai, developer-tools, kapa]
-sidebar_position: 10
+sidebar_position: 2
 ---
 
 # Kapa MCP server
@@ -51,4 +50,4 @@ Kapa indexes a curated set of Midnight sources: the official documentation, hand
 
 ## Midnight Expert
 
-For hands-on development tasks like writing and validating Compact contracts, running a local devnet, or decoding error codes, use [Midnight Expert](https://midnightntwrk.expert/) alongside Kapa. See the [Midnight agent skills](midnight-agent-skills) page or the [migration blog post](/blog/migrating-to-kapa-and-midnight-expert) for setup instructions.
+For hands-on development tasks like writing and validating Compact contracts, running a local devnet, or decoding error codes, use [Midnight Expert](/ai-integration/midnight-expert) alongside Kapa. See the [Midnight agent skills](/sdks/community/ai-tools/midnight-agent-skills) page or the [migration blog post](/blog/migrating-to-kapa-and-midnight-expert) for setup instructions.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,6 +171,11 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         redirects: [
+          // Kapa MCP server moved from community to the core AI integration section
+          {
+            from: '/sdks/community/ai-tools/kapa-mcp-server',
+            to: '/ai-integration/kapa-mcp-server',
+          },
           // Academy redirects (external)
           {
             from: [


### PR DESCRIPTION
## Summary

Relocates the **Kapa MCP server** page out of the community section and into the core **AI integration** section.

Kapa is an officially supported Midnight Foundation tool — it exposes the same knowledge base that powers the "Ask AI" button on these docs — not a third-party community contribution. It was sitting under `sdks/community/ai-tools/` alongside community-built projects, which mislabels its support status and separates it from the other first-party AI tooling (Midnight Expert) it's meant to be used with. This move puts it where it belongs and lets the two official tools cross-link as siblings.

### Changes

- Moved `sdks/community/ai-tools/kapa-mcp-server.mdx` → `docs/ai-integration/kapa-mcp-server.mdx` (new URL: `/ai-integration/kapa-mcp-server`).
- Set `sidebar_position: 2` so it follows Midnight Expert (1); dropped the now-redundant `slug`. Both sidebars are autogenerated, so no manual sidebar edits are needed.
- Fixed two internal links that were relative to the old location: "Midnight Expert" now points to the internal `/ai-integration/midnight-expert` page, and "Midnight agent skills" to `/sdks/community/ai-tools/midnight-agent-skills`.
- Added a client redirect from the old community URL to the new one so existing links and bookmarks don't 404.

## Type of Change
- [x] Documentation update (content fixes, new pages)
- [x] Site improvement (UI/UX, infrastructure)
- [ ] New blog post
- [ ] Other (please specify)

## Related Links
- Documentation page(s) updated: `/ai-integration/kapa-mcp-server` (moved from `/sdks/community/ai-tools/kapa-mcp-server`)
- Redirect added in `docusaurus.config.js`

## Issue Reference
_No related issue._

## Checklist
- [x] Followed the [Midnight Style Guide](https://docs.midnight.network/contributing/style-guide).
- [x] Previewed changes locally (`npm run build` passes; new page and redirect stub both emit, no broken links).
- [x] Updated navigation metadata if needed (sidebar, menus).

## Notes

The community `ai-tools` folder retains the genuinely third-party entries (Midnight agent skills). Only Kapa moves, since it's the one first-party tool that was misfiled there.
