### PR TITLE
fix: update link

### DIFF
--- a/blog/2026-06-25-migrating-to-kapa-and-midnight-expert.mdx
+++ b/blog/2026-06-25-migrating-to-kapa-and-midnight-expert.mdx
@@ -55,7 +55,7 @@ Some clients label this a remote or HTTP server and ask for a transport field; t
 
 ## Midnight Expert: the hands-on toolkit
 
-Where Kapa answers questions, Midnight Expert does the work. It's a [marketplace of Claude Code plugins](https://github.com/devrelaicom/midnight-expert), and it's where the generation, validation, and tooling features of the old server now live, with broader coverage.
+Where Kapa answers questions, Midnight Expert does the work. It's a [marketplace of Claude Code plugins](https://github.com/midnightntwrk/midnight-expert), and it's where the generation, validation, and tooling features of the old server now live, with broader coverage.
 
 At the moment it bundles more than fifteen plugins: over a hundred skills, more than a dozen agents, and a couple hundred reference documents covering Compact contracts, the TypeScript SDK, wallet operations, devnet and proof server infrastructure, code quality, and error catalogs. Because the plugins run inside Claude Code, the capabilities show up as skills and slash commands you can call directly in a session.
 


### PR DESCRIPTION
## Summary

Updates the last remaining `devrelaicom/midnight-expert` link in the docs to the migrated `midnightntwrk/midnight-expert` repo, following the code migration from the `devrelaicom` org to `midnightntwrk`.

## Change

- `blog/2026-06-25-migrating-to-kapa-and-midnight-expert.mdx` — the Claude Code plugins marketplace link now points to `https://github.com/midnightntwrk/midnight-expert`.

The `docs/ai-integration/midnight-expert.mdx` references called out in the issue already point to `midnightntwrk`, so this blog link was the only outstanding `devrelaicom` reference in the docs.

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)