### PR TITLE
fix: re-add npmMinimalAgeGate to .yarnrc.yml

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
 enableHardenedMode: false
 
 nodeLinker: node-modules
+
+# Wait 7 days before resolving newly published package versions
+# to reduce exposure to npm supply chain attacks.
+npmMinimalAgeGate: "7d"


### PR DESCRIPTION
## Summary
- Re-adds `npmMinimalAgeGate: "7d"` to `.yarnrc.yml`, so Yarn waits 7 days before resolving newly published package versions, reducing exposure to npm supply chain attacks.
- This restores the setting reverted in 6578f479 (12 Aug), when Vercel's native build image bundled a Yarn older than 4.10 and hard-errored on the key. Re-tested on 31 Aug with a canary branch off main: the native Vercel deploy now succeeds with the gate alone, no corepack install override needed.
- CI is unaffected: every workflow already pins `yarn@4.12.0` via corepack, and the gate only applies when resolving new versions, not to `--immutable` installs from the existing lockfile.

## Type of Change
- [x] Site improvement (UI/UX, infrastructure)

## Related Links
- Resolves code scanning alert 249: https://github.com/midnightntwrk/midnight-docs/security/code-scanning/249
- Yarn reference: https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate

## Issue Reference


## Checklist
- [x] Previewed changes locally (`npm run start` or `yarn start`).

## Notes
One practical effect for future dependency work: resolutions and upgrades must target versions published at least 7 days ago, or `yarn install` will refuse to resolve them.