### PR TITLE
ci: watch product repos for undocumented stable releases

### DIFF
--- a/.github/workflows/release-watch.yml
+++ b/.github/workflows/release-watch.yml
@@ -1,0 +1,40 @@
+# This file is part of midnight-docs.
+# Copyright (C) Midnight Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Watches the Midnight product repos for stable releases that have no release
+# notes in the docs, and opens one issue per missing component version.
+# Detection logic lives in scripts/check-release-gaps.mjs.
+
+name: Release notes watch
+
+on:
+  schedule:
+    - cron: '17 7 * * *' # daily, 07:17 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report gaps without opening issues'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-release-gaps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
+        with:
+          node-version: 22
+
+      - name: Check for undocumented releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run == true && '1' || '' }}
+        run: node scripts/check-release-gaps.mjs

--- a/scripts/check-release-gaps.mjs
+++ b/scripts/check-release-gaps.mjs
@@ -1,0 +1,172 @@
+// This file is part of midnight-docs.
+// Copyright (C) Midnight Foundation
+// SPDX-License-Identifier: Apache-2.0
+//
+// Detects upstream component releases that have no release notes in the docs.
+//
+// For each component, the script fetches the GitHub releases of the product
+// repo, keeps only stable releases (not draft, not prerelease, and a clean
+// x.y.z tag with no rc/beta/alpha suffix), and compares the highest stable
+// version against the newest entry in the component's DynamicList file.
+// Both filters matter: some repos forget the prerelease flag on betas, and
+// some flag clean-tagged builds as prereleases.
+//
+// When a gap is found, the script opens one GitHub issue per component and
+// version (title: "Release notes gap: <component> <version>"). An issue that
+// already exists for that title, open or closed, is never recreated, so
+// closing an issue as "won't document" silences that version for good.
+//
+// Usage:
+//   GITHUB_TOKEN=... node scripts/check-release-gaps.mjs           # detect + open issues
+//   GITHUB_TOKEN=... DRY_RUN=1 node scripts/check-release-gaps.mjs # detect only
+//
+// Runs daily via .github/workflows/release-watch.yml.
+
+import { readFileSync, existsSync, appendFileSync } from 'node:fs';
+
+const DOCS_REPO = process.env.GITHUB_REPOSITORY ?? 'midnightntwrk/midnight-docs';
+const TOKEN = process.env.GITHUB_TOKEN;
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+if (!TOKEN) {
+  console.error('GITHUB_TOKEN is required');
+  process.exit(1);
+}
+
+// tag: anchored regex whose first capture group is the x.y.z version.
+const COMPONENTS = [
+  { name: 'Node',               repo: 'midnightntwrk/midnight-node',               tag: /^node-(\d+\.\d+\.\d+)$/,                                  list: 'src/components/DynamicListNode.js' },
+  { name: 'Ledger',             repo: 'midnightntwrk/midnight-ledger',             tag: /^ledger-(\d+\.\d+\.\d+)$/,                                list: 'src/components/DynamicListLedger.js' },
+  { name: 'Midnight Indexer',   repo: 'midnightntwrk/midnight-indexer',            tag: /^v(\d+\.\d+\.\d+)$/,                                      list: 'src/components/DynamicListMidnightIndexer.js' },
+  { name: 'Midnight.js',        repo: 'midnightntwrk/midnight-js',                 tag: /^v(\d+\.\d+\.\d+)$/,                                      list: 'src/components/DynamicListMidnightJS.js' },
+  { name: 'DApp Connector API', repo: 'midnightntwrk/midnight-dapp-connector-api', tag: /^v(\d+\.\d+\.\d+)$/,                                      list: 'src/components/DynamicListDappConnectorAPI.js' },
+  { name: 'Compact toolchain',  repo: 'midnightntwrk/compact',                     tag: /^compactc-v(\d+\.\d+\.\d+)$/,                             list: 'src/components/DynamicListCompact.js' },
+  { name: 'Compact devtools',   repo: 'midnightntwrk/compact',                     tag: /^compact-v(\d+\.\d+\.\d+)$/,                              list: 'src/components/DynamicListCompactTools.js' },
+  { name: 'Compact JS',         repo: 'midnightntwrk/midnight-sdk',                tag: /^compact-js-v(\d+\.\d+\.\d+)$/,                           list: 'src/components/DynamicListCompactJS.js' },
+  { name: 'Wallet SDK',         repo: 'midnightntwrk/midnight-wallet',             tag: /^@midnight-?ntwrk\/wallet-sdk-facade@(\d+\.\d+\.\d+)$/,   list: 'src/components/DynamicListWallet.js' },
+];
+
+const api = async (path) => {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!res.ok) throw new Error(`GET ${path} -> ${res.status} ${await res.text()}`);
+  return res.json();
+};
+
+const cmpVersion = (a, b) => {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+};
+
+const documentedVersion = (listFile) => {
+  if (!existsSync(listFile)) return null;
+  const m = readFileSync(listFile, 'utf8').match(/version: '([^']+)'/);
+  return m ? m[1] : null;
+};
+
+const latestStable = async (component) => {
+  // Two pages cover repos whose recent history is dominated by prereleases.
+  const releases = [
+    ...(await api(`/repos/${component.repo}/releases?per_page=100`)),
+    ...(await api(`/repos/${component.repo}/releases?per_page=100&page=2`)),
+  ];
+  let best = null;
+  for (const r of releases) {
+    if (r.draft || r.prerelease) continue;
+    const m = r.tag_name.match(component.tag);
+    if (!m) continue;
+    if (!best || cmpVersion(m[1], best.version) > 0) {
+      best = { version: m[1], url: r.html_url, publishedAt: r.published_at };
+    }
+  }
+  return best;
+};
+
+const issueExists = async (title) => {
+  const q = encodeURIComponent(`repo:${DOCS_REPO} is:issue in:title "${title}"`);
+  const found = await api(`/search/issues?q=${q}&per_page=20`);
+  return found.items.some((i) => i.title === title);
+};
+
+const openIssue = async (title, body) => {
+  const res = await fetch(`https://api.github.com/repos/${DOCS_REPO}/issues`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({ title, body }),
+  });
+  if (!res.ok) throw new Error(`POST issue -> ${res.status} ${await res.text()}`);
+  return (await res.json()).html_url;
+};
+
+const rows = [];
+let gaps = 0;
+
+for (const c of COMPONENTS) {
+  const documented = documentedVersion(c.list);
+  let upstream;
+  try {
+    upstream = await latestStable(c);
+  } catch (e) {
+    rows.push([c.name, documented ?? '?', 'lookup failed', ':warning:']);
+    console.error(`${c.name}: ${e.message}`);
+    continue;
+  }
+  if (!upstream || !documented) {
+    rows.push([c.name, documented ?? 'none', upstream?.version ?? 'none', ':grey_question:']);
+    continue;
+  }
+  if (cmpVersion(upstream.version, documented) <= 0) {
+    rows.push([c.name, documented, upstream.version, ':white_check_mark:']);
+    continue;
+  }
+
+  gaps++;
+  rows.push([c.name, documented, upstream.version, ':x: gap']);
+  const title = `Release notes gap: ${c.name} ${upstream.version}`;
+  const body = [
+    `The latest stable ${c.name} release has no release notes in the docs.`,
+    '',
+    `- Documented (newest entry in \`${c.list}\`): **${documented}**`,
+    `- Upstream stable: **${upstream.version}**, published ${upstream.publishedAt?.slice(0, 10)}`,
+    `- Release: ${upstream.url}`,
+    '',
+    'To resolve, run the `sync-release-notes.yml` workflow for this component (or add the notes manually), fill in the DynamicList entry, and check whether the support matrix needs an update.',
+    '',
+    'Opened automatically by `release-watch.yml`. Closing this issue without documenting the release permanently silences this version.',
+  ].join('\n');
+
+  if (DRY_RUN) {
+    console.log(`[dry-run] would open issue: ${title}`);
+  } else if (await issueExists(title)) {
+    console.log(`issue already exists: ${title}`);
+  } else {
+    console.log(`opened: ${await openIssue(title, body)}`);
+  }
+}
+
+const table = [
+  '## Release notes coverage',
+  '',
+  '| Component | Documented | Upstream stable | Status |',
+  '|---|---|---|---|',
+  ...rows.map((r) => `| ${r.join(' | ')} |`),
+  '',
+  gaps === 0 ? 'No gaps detected.' : `${gaps} gap(s) detected.`,
+].join('\n');
+
+console.log(table);
+if (process.env.GITHUB_STEP_SUMMARY) appendFileSync(process.env.GITHUB_STEP_SUMMARY, table + '\n');


### PR DESCRIPTION
## Summary

Closes the detection hole in the release notes process: today nothing tells us when a product repo ships, so gaps are found by manually diffing (which is how the recent node/ledger/wallet backfills were discovered, and how the wallet one still slipped a first audit).

Adds a daily `release-watch.yml` workflow backed by `scripts/check-release-gaps.mjs`:

- For each of nine components (node, ledger, indexer, Midnight.js, DApp Connector, Compact toolchain, Compact devtools, Compact JS, Wallet SDK facade), it fetches the product repo's releases and keeps only stable ones. Two filters are applied deliberately: the `prerelease` flag AND a clean `x.y.z` tag pattern, because midnight-js has betas not flagged as prereleases and the indexer flags clean-tagged builds as prereleases. Both real-world quirks are covered.
- The highest stable version is compared against the newest entry in the component's DynamicList.
- Each gap opens one issue titled `Release notes gap: <component> <version>` with the release link and the resolution steps. An existing issue with that title, open or closed, is never recreated, so closing an issue as "won't document" silences that version permanently.
- A coverage table lands in the workflow step summary on every run, and `workflow_dispatch` has a dry-run input for testing.

## Validation

Dry run against current main detects exactly the two known gaps and nothing else:

| Component | Documented | Upstream stable | Status |
|---|---|---|---|
| Ledger | 8.1.0 | 8.1.1 | gap (PR #1274 in review) |
| Wallet SDK | 3.0.0 | 4.1.0 | gap (PR #1289 in review) |
| Other seven | current | current | ok |

## Scope notes

- Proof server and on-chain runtime have no public release tags; Lace is a private repo the workflow token cannot read; pubsub-indexer and examples are dormant; faucet's release hygiene is too noisy to watch usefully (an alpha is currently tagged Latest). All skipped deliberately.
- Permissions are minimal (`contents: read`, `issues: write`), actions are SHA-pinned per repo convention, and the wallet facade tag regex matches both the old `@midnight-ntwrk` and new `@midnightntwrk` scopes.