### PR TITLE
fix: correct cross-contract call and merging statements in building-blocks

### DIFF
--- a/docs/concepts/how-midnight-works/building-blocks.mdx
+++ b/docs/concepts/how-midnight-works/building-blocks.mdx
@@ -43,9 +43,9 @@ for cross-contract interaction.
 
 :::info
 
-Cross-contract interaction is still under development and is not available for
-use at this time. The team is keen to hear what kinds of interactions you would like
-to be able to do.
+Cross-contract calls are supported as of Compact toolchain 0.33.0. See
+[cross-contract calls](../../compact/reference/compact-reference.mdx#cross-contract-calls)
+for the syntax and its restrictions.
 
 :::
 
@@ -55,10 +55,11 @@ are valid for this contract and binding to other transaction elements.
 ## Merging
 
 Zswap permits atomic swaps by allowing transactions to be merged.
-Currently, contract call sections cannot be merged, but 
-two transactions can be merged if at least one of them has an empty contract call
-section. This outputs a new, composite transaction and has the effect of both
-input transactions combined.
+Two transactions can be merged when they share a network id, their intents do not
+collide on a segment id, and their coin offers merge cleanly. Merging unions the
+intents of both transactions, merges their guaranteed and fallible coin offers, and
+sums their binding randomness. This outputs a new, composite transaction and has the
+effect of both input transactions combined.
 
 ## Transaction integrity
 


### PR DESCRIPTION
Fixes two statements on the building-blocks page that describe a superseded transaction model.

Closes #1291

## Cross-contract calls

The page carried an `:::info` admonition saying cross-contract interaction "is still under development and is not available for use at this time."

This contradicts the rest of the site:

- [Toolchain 0.34.0 release notes](https://docs.midnight.network/relnotes/compact/toolchain-0.34.0) — 0.34.0 "builds on 0.33.0, which added support for ledger version 9, **cross-contract calls**, events..."
- [Compact reference — cross-contract calls](https://docs.midnight.network/compact/reference/compact-reference#cross-contract-calls)
- [`crossContractCall()`](https://docs.midnight.network/api-reference/compact-runtime/functions/crossContractCall) in `compact-runtime` 0.19.0
- midnight-js v5.0.0 — "assemble, prove, and submit cross-contract calls" (#967)

Replaced with a pointer to the Compact reference, which carries the actual restrictions (no generic parameters, no witness-calling circuits reachable through a contract type, undefined behaviour on call-graph cycles). I deliberately did not restate those here — they change with the language, and one authoritative copy seems better than two.

## Merging

The page said contract call sections cannot be merged and that two transactions can merge only if at least one has an empty contract call section.

`Transaction::merge` in `ledger/src/structure.rs` rejects on exactly four conditions:

| condition | error |
|---|---|
| network ids differ | `InvalidNetworkId` |
| shared intent segment id | `IntentSegmentIdCollision` |
| coin offers fail to merge | `Zswap(..)` |
| either side is not `Standard` | `CantMergeTypes` |

No empty-contract-call-section check exists. The structure the sentence describes is also gone: `StandardTransaction` is `{ network_id, intents, guaranteed_coins, fallible_coins, binding_randomness }`, and contract calls live inside segment-keyed `intents`, which `merge` unions.

Verified on branch `ledger-9` (line 1485) and on the default `ledger-8` branch (line 1390) — the implementation is identical on both.

## Deliberately out of scope

The **Transactions** section at the top of the page still describes a transaction as "a guaranteed Zswap offer / an optional fallible Zswap offer / an optional contract calls segment," which is the same pre-intents model. That is a larger rewrite and a judgement call about how much protocol detail this conceptual page should carry, so I left it out rather than guess. Happy to extend this PR if you would like it covered here.

## How this surfaced

We hit both while building on Compact 0.34.0 / ledger 9.1.0.0-rc.3. We recorded "no contract-to-contract calls" as a hard constraint from this page and designed around it, only catching it later against the release notes. In both cases the release notes and API reference were already correct — the drift looks specific to this conceptual page.
