### PR TITLE
Correct shielded and unshielded token semantics in tokens and ledgers docs

### DIFF
--- a/docs/concepts/ledgers.mdx
+++ b/docs/concepts/ledgers.mdx
@@ -36,7 +36,7 @@ Different applications have different needs. Midnight supports both token approa
 
 **Ledger tokens (UTXO-based)** - These are native to Midnight's blockchain ledger itself. NIGHT tokens—Midnight's native utility token—are the prime example. 
 NIGHT tokens exist as individual UTXOs directly on the ledger and serve a special purpose: they generate DUST, the renewable resource that powers all transactions on Midnight. 
-Each NIGHT token UTXO has a specific value and owner, and spending them follows the UTXO pattern of consuming inputs and creating outputs. This UTXO structure is crucial because it enables Midnight's privacy features—individual UTXOs can be shielded or unshielded as needed.
+Each NIGHT token UTXO has a specific value and owner, and spending them follows the UTXO pattern of consuming inputs and creating outputs. This UTXO structure is crucial because it underpins Midnight's privacy features—a coin's privacy comes from its token type, and shielded tokens are tracked as their own UTXOs. NIGHT itself is unshielded, so NIGHT UTXOs and the transfers that spend them are public.
 
 **Contract tokens (Account-based)** - These live inside smart contracts written in Compact (Midnight's smart contract language) and work just like ERC-20 tokens you know from Ethereum. The contract maintains a mapping of addresses to balances, and transfers simply update these balance numbers. These tokens follow OpenZeppelin-style standards adapted for Compact, so if you're comfortable with Solidity token development, contract tokens will feel immediately familiar. Contract tokens can also support both shielded and unshielded operations, giving you privacy options even within the account model.
 
@@ -130,7 +130,7 @@ Understanding these models is practical preparation for building on Midnight. Ch
 | Use case                   | Best choice               | Why this model works                         | Example applications                          |
 |----------------------------|---------------------------|----------------------------------------------|-----------------------------------------------|
 | High-volume payments       | Ledger tokens (UTXO)      | Parallel transaction processing              | Payment processors, remittance systems        |
-| Private transactions       | Ledger tokens (UTXO)      | Individual UTXOs can be shielded            | Confidential transfers, private auctions      |
+| Private transactions       | Ledger tokens (UTXO)      | Shielded UTXOs hide amounts and owners       | Confidential transfers, private auctions      |
 | Cross-chain bridges        | Ledger tokens (UTXO)      | Atomic operations and clear ownership        | Bridge protocols, wrapped assets              |
 | Complex DeFi logic         | Contract tokens (account) | Rich state management capabilities           | AMMs, lending protocols, yield farming        |
 | Gaming mechanics           | Contract tokens (account) | Complex rules and interactions               | In-game currencies, item crafting             |

--- a/docs/tokens/overview.mdx
+++ b/docs/tokens/overview.mdx
@@ -25,8 +25,8 @@ For the economic rationale behind this design, see [Dual-component tokenomics](/
 
 Midnight's dual ledger lets tokens exist in two forms:
 
-- **Shielded**: private state where wallet addresses and transaction details stay confidential. 1AM and urble default to shielded.
-- **Unshielded**: public state visible on the ledger, similar to transparent blockchains. Lace is opt-in for shielded.
+- **Shielded**: private state where wallet addresses and transaction details stay confidential. DUST is always shielded, as are tokens minted with `mintShieldedToken`.
+- **Unshielded**: public state visible on the ledger, similar to transparent blockchains. NIGHT is always unshielded, as are tokens minted with `mintUnshieldedToken`.
 
 A token's privacy comes from its token type, not from the address that holds it. NIGHT is an unshielded token: its balances and transfers are always public, and holding NIGHT at a shielded address does not make it private. There is no mechanism to move a token between shielded and unshielded state, shielded and unshielded tokens are distinct token types, tracked in separate pools. For code examples of shielded and unshielded token transfers in Compact, see [Token transfers](/examples/contracts/token-transfers).
 

--- a/docs/tokens/overview.mdx
+++ b/docs/tokens/overview.mdx
@@ -28,7 +28,7 @@ Midnight's dual ledger lets tokens exist in two forms:
 - **Shielded**: private state where wallet addresses and transaction details stay confidential. 1AM and urble default to shielded.
 - **Unshielded**: public state visible on the ledger, similar to transparent blockchains. Lace is opt-in for shielded.
 
-Both NIGHT and custom tokens can move between shielded and unshielded state. For code examples of shielded and unshielded token transfers in Compact, see [Token transfers](/examples/contracts/token-transfers).
+A token's privacy comes from its token type, not from the address that holds it. NIGHT is an unshielded token: its balances and transfers are always public, and holding NIGHT at a shielded address does not make it private. There is no mechanism to move a token between shielded and unshielded state, shielded and unshielded tokens are distinct token types, tracked in separate pools. For code examples of shielded and unshielded token transfers in Compact, see [Token transfers](/examples/contracts/token-transfers).
 
 ## Custom tokens
 


### PR DESCRIPTION
## Summary

Corrects the shielded/unshielded model across the tokens overview and the ledgers concept page, and removes two garbled sentences.

`docs/tokens/overview.mdx` previously stated:

> Both NIGHT and custom tokens can move between shielded and unshielded state.

This is not accurate. Shielded and unshielded are **distinct token types tracked in separate pools**, with no conversion between them, and **NIGHT is unshielded** — its balances and transfers are always public, regardless of the address holding it. A token's privacy comes from its token type, not from the address that holds it.

Three commits:

1. **`docs/tokens/overview.mdx`** — replace the "can move between shielded and unshielded state" claim with the token-type rule.
2. **`docs/concepts/ledgers.mdx`** — apply the same correction in the two places that said the opposite.
3. **`docs/tokens/overview.mdx`** — replace two garbled sentences in the shielded/unshielded bullets.

## Type of Change
- [x] Documentation update (content fixes, new pages)
- [ ] Site improvement (UI/UX, infrastructure)
- [ ] New blog post
- [ ] Other (please specify)

## Related Links
- `docs/tokens/overview.mdx` (`/tokens/overview`), "Shielded and unshielded" section
- `docs/concepts/ledgers.mdx` (`/concepts/ledgers`), "Why this matters for token development" and "Choosing the right token type"

## Issue Reference
<!-- No related issue. -->

## Checklist
- [x] Followed the [Midnight Style Guide](https://docs.midnight.network/contributing/style-guide).
- [ ] Previewed changes locally (`npm run start` or `yarn start`) — prose-only changes, no structural or component edits.
- [x] Updated navigation metadata if needed (sidebar, menus).

## Notes

**Evidence for the correction**, checked against this repo and the Compact standard library reference:

| Claim | Supporting source |
|---|---|
| NIGHT is unshielded | `docs/concepts/dual-component-tokenomics.mdx:23` — "**NIGHT** – the unshielded utility token used for staking, securing the network, and governance" |
| Shielded and unshielded are distinct token types | `docs/compact/standard-library/exports.md` exposes two parallel, non-intersecting families: `mintShieldedToken` / `sendShielded` / `receiveShielded` against `mintUnshieldedToken` / `sendUnshielded` / `receiveUnshielded` |
| Distinct at the type level too | Shielded operations use `ShieldedCoinInfo` / `QualifiedShieldedCoinInfo` / `ZswapCoinPublicKey`; unshielded operations use `UserAddress` |
| No conversion mechanism | The complete list of shielded/unshielded circuits in the stdlib exports contains no shield or unshield conversion circuit |

### On the two garbled sentences

The shielded bullet ended with "**1AM and urble** default to shielded" — not a Midnight term, and it appears nowhere else in the repo. The unshielded bullet ended with "**Lace is opt-in for shielded**", which misstates the wallet.

Both date back to `c007861f`, the commit that first added the Tokens section, and survived a later review pass in `a74e9f72`, so there is no earlier correct wording in history to restore. They are replaced with statements grounded in the rest of the docs:

- Lace keeps **separate** shielded and unshielded addresses rather than a shielded mode — see `docs/guides/_lace-wallet.mdx:82` ("copy your Unshielded wallet address") and `docs/guides/acquire-tokens.mdx:35` ("the faucet rejects shielded and DUST addresses").
- DUST is shielded, per this same page and `docs/concepts/dust-architecture.mdx`.

Each bullet now names the tokens its form applies to, which also reinforces the token-type rule in the paragraph below.

### Scope note

`docs/concepts/ledgers.mdx:41` says contract tokens "can also support both shielded and unshielded operations." That is a different statement from the one corrected here and is left alone.

### Verification limits

Claims were checked against this repository's own documentation and the Compact standard library reference, not against ledger source or by execution. Worth a maintainer's eye on the protocol-level wording in particular.
