### PR TITLE
docs(examples): add Leaderboard DApp tile to the DApps landing page

### DIFF
--- a/docs/examples/dapps/index.mdx
+++ b/docs/examples/dapps/index.mdx
@@ -29,6 +29,12 @@ Looking for a specific feature? The [Examples overview](/examples) maps every ex
       cta: "View bulletin board DApp"
     },
     {
+      title: "Leaderboard DApp",
+      body: "Submit game scores with configurable privacy modes. ZK proofs verify entry ownership without revealing the player's identity.",
+      to: "/examples/dapps/leaderboard",
+      cta: "View leaderboard DApp"
+    },
+    {
       title: "ZK Loan DApp",
       body: "Evaluate loan eligibility against private credit data. The credit score and income never leave your machine.",
       to: "/examples/dapps/zkloan",


### PR DESCRIPTION
## Summary
- The DApps landing page at `/examples/dapps` shows tiles for the Bulletin board and ZK Loan examples but not for the Leaderboard example, even though that page already lives at `/examples/dapps/leaderboard`. This adds the missing tile between the two, matching the sidebar order (bboard 20, leaderboard 25, zkloan 30).
- Tile copy is drawn from the Leaderboard page's own intro: score submission with configurable privacy modes, and ZK proofs that verify entry ownership without revealing the player's identity.


