### PR TITLE
docs: replace stale testnet-02 endpoints with Preview in validator + wallet guides

### DIFF
--- a/docs/nodes/_run-a-validator/index.mdx
+++ b/docs/nodes/_run-a-validator/index.mdx
@@ -171,7 +171,7 @@ An existing Cardano relay node can be repurposed for `cardano-db-sync` if the op
 
 Midnight-node uses partner-chains CLI commands which require on an Ogmios connect. While you may run Ogmios locally, we provide a public endpoint for the service.
 
-* [ogmios.testnet-02.midnight.network](https://ogmios.testnet-02.midnight.network)
+* The former public Ogmios endpoint (`ogmios.testnet-02.midnight.network`) has been retired along with the `testnet-02` network and no longer resolves. Run Ogmios locally, and see [Networks and environments](/guides/networks-and-environments) for the current endpoints.
 
 ### Network and Security Considerations for Testnet:
 

--- a/docs/nodes/_run-a-validator/step-1.mdx
+++ b/docs/nodes/_run-a-validator/step-1.mdx
@@ -13,7 +13,7 @@ To embark on the path of becoming a Midnight validator, one must either be, or b
 
 | Cardano env. | Status | Midnight env.
 |----------|----------|----------|
-| `preview` | ✅ | `testnet-02` |
+| `preview` | ✅ | `preview` (the `testnet-02` network has been retired; see [Networks and environments](/guides/networks-and-environments)) |
 | `preprod` | ❌ | N/A |
 | `mainnet` | ❌ | N/A |
 

--- a/docs/nodes/_run-a-validator/step-3.mdx
+++ b/docs/nodes/_run-a-validator/step-3.mdx
@@ -428,21 +428,12 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "sidechain_getStatus",
       "params": [INSERT_EPOCH],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 Example output:
 
-```bash
-curl -L -X POST -H "Content-Type: application/json" -d '{
-      "jsonrpc": "2.0",
-      "method": "sidechain_getStatus",
-      "params": [],
-      "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100   297  100   193  100   104    395    213 --:--:-- --:--:-- --:--:--   608
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -469,7 +460,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "systemParameters_getAriadneParameters",
       "params": [697],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 Look for your registration under `"candidateRegistrations": {)`. Ensure you see your Partner-chain keys in the registration and  `"isValid": true`
@@ -516,7 +507,7 @@ curl -L -X POST -H "Content-Type: application/json" -d '{
       "method": "systemParameters_getAriadneParameters",
       "params": [INSERT_EPOCH],
       "id": 1
-    }' https://rpc.testnet-02.midnight.network | jq
+    }' https://rpc.preview.midnight.network | jq
 ```
 
 You should see your candidate is no longer on the list.

--- a/main_versioned_docs/version-0.0.0/develop/guides/wallet-dev-guide.mdx
+++ b/main_versioned_docs/version-0.0.0/develop/guides/wallet-dev-guide.mdx
@@ -131,10 +131,10 @@ import { WalletBuilder } from '@midnight-ntwrk/wallet';
 import { NetworkId } from '@midnight-ntwrk/zswap';
 
 const wallet = await WalletBuilder.build(
-  'https://indexer.testnet-02.midnight.network/api/v1/graphql', // Indexer URL
-  'wss://indexer.testnet-02.midnight.network/api/v1/graphql/ws', // Indexer WebSocket URL
+  'https://indexer.preview.midnight.network/api/v4/graphql', // Indexer URL
+  'wss://indexer.preview.midnight.network/api/v4/graphql/ws', // Indexer WebSocket URL
   'http://localhost:6300', // Proving Server URL
-  'https://rpc.testnet-02.midnight.network', // Node URL
+  'https://rpc.preview.midnight.network', // Node URL
   '0000000000000000000000000000000000000000000000000000000000000000',
   NetworkId.TestNet,
   'error' // LogLevel
@@ -169,10 +169,10 @@ import { generateRandomSeed } from '@midnight-ntwrk/wallet-sdk-hd';
 const randomSeed = generateRandomSeed();
 
 const wallet = await WalletBuilder.build(
-  'https://indexer.testnet-02.midnight.network/api/v1/graphql', // Indexer URL
-  'wss://indexer.testnet-02.midnight.network/api/v1/graphql/ws', // Indexer WebSocket URL
+  'https://indexer.preview.midnight.network/api/v4/graphql', // Indexer URL
+  'wss://indexer.preview.midnight.network/api/v4/graphql/ws', // Indexer WebSocket URL
   'http://localhost:6300', // Proving Server URL
-  'https://rpc.testnet-02.midnight.network',  // Node URL
+  'https://rpc.preview.midnight.network',  // Node URL
   randomSeed,
   NetworkId.TestNet,
   'error'
@@ -212,10 +212,10 @@ const originalWallet = await WalletBuilder.build(/* ... */);
 const serializedState = await originalWallet.serialize();
 
 const restoredWallet = await WalletBuilder.restore(
-  'https://indexer.testnet-02.midnight.network/api/v1/graphql', // Indexer URL
-  'wss://indexer.testnet-02.midnight.network/api/v1/graphql/ws', // Indexer WebSocket URL
+  'https://indexer.preview.midnight.network/api/v4/graphql', // Indexer URL
+  'wss://indexer.preview.midnight.network/api/v4/graphql/ws', // Indexer WebSocket URL
   'http://localhost:6300', // Proving Server URL
-  'https://rpc.testnet-02.midnight.network', // Node URL
+  'https://rpc.preview.midnight.network', // Node URL
   '0000000000000000000000000000000000000000000000000000000000000000', // seed associated with serializedState
   serializedState,
   'error'
@@ -426,10 +426,10 @@ import { NetworkId, nativeToken } from '@midnight-ntwrk/zswap';
 
 try {
   const wallet = await WalletBuilder.build(
-    'https://indexer.testnet-02.midnight.network/api/v1/graphql',
-    'wss://indexer.testnet-02.midnight.network/api/v1/graphql/ws',
+    'https://indexer.preview.midnight.network/api/v4/graphql',
+    'wss://indexer.preview.midnight.network/api/v4/graphql/ws',
     'http://localhost:6300',
-    'https://rpc.testnet-02.midnight.network',
+    'https://rpc.preview.midnight.network',
     '0000000000000000000000000000000000000000000000000000000000000000',
     NetworkId.TestNet
   );


### PR DESCRIPTION
Partial fix for #1172 — covers the stale `testnet-02` references that live in this repo (`midnight-node-docker`'s README/.envrc are separate).

`rpc.testnet-02.midnight.network` / `indexer.testnet-02.midnight.network` no longer resolve (NXDOMAIN since the 2026-01-27 Preview transition), which sends new integrators to a dead endpoint. This updates the user-facing guides.

**Changes**
- `nodes/run-a-validator/step-3.mdx` — point the validator-status `curl` queries at `rpc.preview.midnight.network`. Also fixes the `sidechain_getStatus` "Example output" block, which mistakenly contained the `curl` command rather than only the JSON response.
- `nodes/run-a-validator/step-1.mdx` — update the supported-environments table (`testnet-02` is retired; the flow targets the Preview-era testnet) and link to the [Networks and environments](/guides/networks-and-environments) reference.
- `nodes/run-a-validator/index.mdx` — remove the `ogmios.testnet-02.midnight.network` public-endpoint link (that domain no longer resolves); direct readers to the current endpoints page.
- `main_versioned_docs/version-0.0.0/develop/guides/wallet-dev-guide.mdx` — update the `WalletBuilder` code examples from the dead `testnet-02` endpoints (`api/v1`) to the current Preview endpoints (`api/v4`).

Release notes and other historical records that mention `testnet-02` are intentionally left as-is.