### PR TITLE
Add ledger v8.1.2 release notes

### DIFF
--- a/docs/relnotes/ledger/ledger-8-1-2.mdx
+++ b/docs/relnotes/ledger/ledger-8-1-2.mdx
@@ -1,0 +1,85 @@
+# Ledger 8.1.2 Release Notes
+
+**Version:** 8.1.2
+**Date:** 2026-08-24
+
+## High-level summary
+
+Ledger 8.1.2 fixes multiple encoding strictness issues that could have led to
+security issues down the line. This release was delivered to mainnet nodes
+prior to this public release.
+
+## Audience
+
+This release note is important for:
+
+- Node developers
+
+## Summary of updates
+
+### Ledger Updates
+
+Security patch. All bumps are patch-level so that the release reads as one, even
+where an individual change carries wider semver implications; internal dependency
+requirements are pinned to the new exact versions so that consumers cannot
+resolve past the fix.
+
+- security: hardening of low-level deserialization across `serialize`,
+  `base-crypto`, `storage`, `onchain-state`, `onchain-vm` and
+  `transient-crypto`. Encodings that are not canonical, and values violating
+  their type's invariant, are now rejected rather than decoded. This narrows what
+  deserializes: an 8.1.2 node rejects data an 8.1.1 node accepts. See the
+  per-crate changelogs for the individual rules.
+- fix: `DustParameters::time_to_cap` guards against a zero
+  `generation_decay_rate` instead of dividing by zero.
+- fix: Dust `seq` increments saturate.
+- fix: Zswap binding randomness extraction no longer panics on a proof preimage
+  with no witness to extract from.
+- fix: delta accumulation in `normalize_deltas` saturates.
+- fix: contract call cost accounting counts public inputs via
+  `ContractCall::public_inputs_len`, with saturating arithmetic, rather than
+  materializing the inputs to take their length.
+
+## New features requiring configuration updates
+
+*None in this release.*
+
+## Deprecations
+
+*None in this release.*
+
+## Breaking changes or required actions for developers
+
+The security changes are breaking to an environment containing maliciously
+formed transactions.
+
+## Fixed defect list
+
+| **Component** | **Description** |
+|---------------|-----------------|
+| serialize | `HashMap` and `HashSet` deserialization requires a normalized encoding (sorted, no duplicate keys); the non-canonical encodings that previously decoded to the same value are rejected. |
+| serialize | Non-canonical `ScaleBigInt` encodings, which use the 4-byte form for a value that fits a smaller form, are rejected. |
+| serialize | `Box<T>` deserialization counts against the recursion depth budget. |
+| serialize | `Vec::with_bounded_capacity` no longer divides by zero for zero-sized types. |
+| serialize | `serialized_size` for `HashMap` and `HashSet` accounts for the actual width of the length prefix. |
+| base-crypto | Non-canonical `Value` and `ValueAtom` encodings are rejected: a singleton value encoded in the multi-entry form, and an atom that fits the single-byte form encoded as multiple bytes. |
+| base-crypto | `AlignedValue` deserialization rejects a value that does not fit its declared alignment. |
+| base-crypto | `Duration::from_hours` saturates instead of overflowing. |
+| storage | `MerklePatriciaTrie` deserialization enforces full structural canonicity rather than annotation consistency alone; a trie whose structure is not uniquely determined by its contents no longer decodes. |
+| storage | An `Extension` node whose declared nibble length disagrees with the length of its encoded path is rejected. |
+| storage | `MultiSet` rejects zero-count entries. |
+| storage | `TimeFilterMap` rejects an encoding whose set and time-map representations disagree. |
+| storage | Nibble-encoded keys reject trailing bytes left over after decoding. |
+| onchain-runtime | `Op` deserialization rejects operands outside their legal encoding bound: `dup`, `swap` and `ins` with `n >= 16`, and `idx` with a path length outside `1..=16`. |
+| onchain-runtime | serde `StateValue` deserialization enforces the type's invariant. |
+| onchain-runtime | Taking the `type` of an array with more than 16 entries is a type error instead of producing an out-of-range tag byte. |
+| onchain-runtime | The Merkle tree bound checks in `idx` and `ins` no longer overflow for large tree heights. |
+| transient-crypto | `VerifierKey` serialization is independent of whether the key has been initialized; initializing in place no longer changes what the key serializes to. |
+| transient-crypto | A verifier key with trailing bytes after the encoded key is rejected, so two encodings cannot map to the same key. |
+| ledger | `DustParameters::time_to_cap` guards against a zero `generation_decay_rate` instead of dividing by zero. |
+| ledger | Dust `seq` increments saturate. |
+| ledger | Contract call cost accounting counts public inputs via `ContractCall::public_inputs_len`, with saturating arithmetic, rather than materializing the inputs to take their length. |
+| zswap | Binding randomness extraction no longer panics on a proof preimage with no witness to extract from. |
+| zswap | Delta accumulation in `normalize_deltas` saturates. |
+| coin-structure, storage-core, zkir | Pull in the hardened `serialize`, `base-crypto`, `storage-core` and `transient-crypto` deserialization. |
+

--- a/docs/relnotes/ledger/ledger-8-1-2.mdx
+++ b/docs/relnotes/ledger/ledger-8-1-2.mdx
@@ -1,62 +1,63 @@
-# Ledger 8.1.2 Release Notes
+---
+SPDX-License-Identifier: Apache-2.0
+copyright: This file is part of midnight-docs. Copyright (C) Midnight Foundation. Licensed under the Apache License, Version 2.0 (the "License"); You may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+title: Ledger v8.1.2 release notes
+description: The Midnight Ledger is the core library for transaction construction, ZKP proving, and on-chain state management on the Midnight Network.
+displayed_sidebar: sidebar
+---
 
-**Version:** 8.1.2
-**Date:** 2026-08-24
+* **Version**: v8.1.2
+* **Date**: August 24, 2026
+
+---
 
 ## High-level summary
 
-Ledger 8.1.2 fixes multiple encoding strictness issues that could have led to
-security issues down the line. This release was delivered to mainnet nodes
-prior to this public release.
+Ledger 8.1.2 is a security patch. It fixes multiple encoding strictness issues that could have led to security issues down the line, hardening low-level deserialization so that non-canonical encodings and values violating their type's invariant are rejected rather than decoded. The release was delivered to mainnet nodes prior to this public release.
+
+All version bumps are patch-level so that the release reads as one, even where an individual change carries wider semver implications, and internal dependency requirements are pinned to the new exact versions so that consumers cannot resolve past the fix.
 
 ## Audience
 
-This release note is important for:
+This release note is most relevant for:
 
-- Node developers
+- Node developers.
 
 ## Summary of updates
 
-### Ledger Updates
+- Security: hardening of low-level deserialization across `serialize`, `base-crypto`, `storage`, `onchain-state`, `onchain-vm`, and `transient-crypto`. Encodings that are not canonical, and values violating their type's invariant, are now rejected rather than decoded. This narrows what deserializes: an 8.1.2 node rejects data an 8.1.1 node accepts. See the per-crate changelogs for the individual rules.
+- Fix: `DustParameters::time_to_cap` guards against a zero `generation_decay_rate` instead of dividing by zero.
+- Fix: Dust `seq` increments saturate.
+- Fix: Zswap binding randomness extraction no longer panics on a proof preimage with no witness to extract from.
+- Fix: delta accumulation in `normalize_deltas` saturates.
+- Fix: contract call cost accounting counts public inputs via `ContractCall::public_inputs_len`, with saturating arithmetic, rather than materializing the inputs to take their length.
 
-Security patch. All bumps are patch-level so that the release reads as one, even
-where an individual change carries wider semver implications; internal dependency
-requirements are pinned to the new exact versions so that consumers cannot
-resolve past the fix.
+---
 
-- security: hardening of low-level deserialization across `serialize`,
-  `base-crypto`, `storage`, `onchain-state`, `onchain-vm` and
-  `transient-crypto`. Encodings that are not canonical, and values violating
-  their type's invariant, are now rejected rather than decoded. This narrows what
-  deserializes: an 8.1.2 node rejects data an 8.1.1 node accepts. See the
-  per-crate changelogs for the individual rules.
-- fix: `DustParameters::time_to_cap` guards against a zero
-  `generation_decay_rate` instead of dividing by zero.
-- fix: Dust `seq` increments saturate.
-- fix: Zswap binding randomness extraction no longer panics on a proof preimage
-  with no witness to extract from.
-- fix: delta accumulation in `normalize_deltas` saturates.
-- fix: contract call cost accounting counts public inputs via
-  `ContractCall::public_inputs_len`, with saturating arithmetic, rather than
-  materializing the inputs to take their length.
+## New features
+
+No new features in this release.
 
 ## New features requiring configuration updates
 
-*None in this release.*
+None in this release.
 
 ## Deprecations
 
-*None in this release.*
+None in this release.
 
-## Breaking changes or required actions for developers
+---
 
-The security changes are breaking to an environment containing maliciously
-formed transactions.
+## Breaking changes or required actions
 
-## Fixed defect list
+The security changes are breaking only for an environment containing maliciously formed transactions: encodings that previously decoded despite being non-canonical no longer do.
 
-| **Component** | **Description** |
-|---------------|-----------------|
+---
+
+## Bug fixes and quality improvements
+
+| Component | Description |
+|-----------|-------------|
 | serialize | `HashMap` and `HashSet` deserialization requires a normalized encoding (sorted, no duplicate keys); the non-canonical encodings that previously decoded to the same value are rejected. |
 | serialize | Non-canonical `ScaleBigInt` encodings, which use the 4-byte form for a value that fits a smaller form, are rejected. |
 | serialize | `Box<T>` deserialization counts against the recursion depth budget. |
@@ -70,7 +71,7 @@ formed transactions.
 | storage | `MultiSet` rejects zero-count entries. |
 | storage | `TimeFilterMap` rejects an encoding whose set and time-map representations disagree. |
 | storage | Nibble-encoded keys reject trailing bytes left over after decoding. |
-| onchain-runtime | `Op` deserialization rejects operands outside their legal encoding bound: `dup`, `swap` and `ins` with `n >= 16`, and `idx` with a path length outside `1..=16`. |
+| onchain-runtime | `Op` deserialization rejects operands outside their legal encoding bound: `dup`, `swap`, and `ins` with `n >= 16`, and `idx` with a path length outside `1..=16`. |
 | onchain-runtime | serde `StateValue` deserialization enforces the type's invariant. |
 | onchain-runtime | Taking the `type` of an array with more than 16 entries is a type error instead of producing an out-of-range tag byte. |
 | onchain-runtime | The Merkle tree bound checks in `idx` and `ins` no longer overflow for large tree heights. |
@@ -81,5 +82,18 @@ formed transactions.
 | ledger | Contract call cost accounting counts public inputs via `ContractCall::public_inputs_len`, with saturating arithmetic, rather than materializing the inputs to take their length. |
 | zswap | Binding randomness extraction no longer panics on a proof preimage with no witness to extract from. |
 | zswap | Delta accumulation in `normalize_deltas` saturates. |
-| coin-structure, storage-core, zkir | Pull in the hardened `serialize`, `base-crypto`, `storage-core` and `transient-crypto` deserialization. |
+| coin-structure, storage-core, zkir | Pull in the hardened `serialize`, `base-crypto`, `storage-core`, and `transient-crypto` deserialization. |
 
+---
+
+## Known issues
+
+No new known issues in this release.
+
+---
+
+## Links and references
+
+- [GitHub release: ledger-8.1.2](https://github.com/midnightntwrk/midnight-ledger/releases/tag/ledger-8.1.2)
+- [`@midnightntwrk/ledger-v8` on npm](https://www.npmjs.com/package/@midnightntwrk/ledger-v8)
+- [Ledger v8.1.1 release notes](/relnotes/ledger/ledger-8-1-1)

--- a/src/components/DynamicListLedger.js
+++ b/src/components/DynamicListLedger.js
@@ -17,8 +17,17 @@ import { useLocation } from '@docusaurus/router';
 
 const releases = [
   {
-    version: '8.1.1',
+    version: '8.1.2',
     status: 'LATEST',
+    date: '04 September 2026',
+    summary: 'Summary of Release 8.1.2',
+    details: [],
+    artifacts: [],
+    link: '/relnotes/ledger/ledger-8-1-2',
+  },
+  {
+    version: '8.1.1',
+    status: 'SUPPORTED',
     date: '31 July 2026',
     summary: 'Patch release with array-handling test coverage and an npm scope change to `@midnightntwrk`',
     details: [

--- a/src/components/DynamicListLedger.js
+++ b/src/components/DynamicListLedger.js
@@ -19,10 +19,19 @@ const releases = [
   {
     version: '8.1.2',
     status: 'LATEST',
-    date: '04 September 2026',
-    summary: 'Summary of Release 8.1.2',
-    details: [],
-    artifacts: [],
+    date: '24 August 2026',
+    summary: 'Security patch hardening deserialization: non-canonical encodings and invariant-violating values are rejected',
+    details: [
+      'Hardens low-level deserialization across `serialize`, `base-crypto`, `storage`, `onchain-state`, `onchain-vm`, and `transient-crypto`: non-canonical encodings and values violating type invariants no longer decode.',
+      'An 8.1.2 node rejects data an 8.1.1 node accepts; the change is breaking only for environments containing maliciously formed transactions.',
+      'Delivered to mainnet nodes prior to the public release.',
+      'Fixes several panic and overflow paths: `DustParameters::time_to_cap` zero-divide guard, saturating Dust `seq` increments and delta accumulation, and Zswap binding randomness extraction no longer panics.',
+      'All bumps are patch-level with internal dependencies pinned exactly, so consumers cannot resolve past the fix.',
+    ],
+    artifacts: [
+      { name: 'Ledger', url: 'https://www.npmjs.com/package/@midnightntwrk/ledger-v8' },
+      { name: 'GitHub release', url: 'https://github.com/midnightntwrk/midnight-ledger/releases/tag/ledger-8.1.2' },
+    ],
     link: '/relnotes/ledger/ledger-8-1-2',
   },
   {


### PR DESCRIPTION
## Summary

Adds the ledger 8.1.2 release notes. Security patch published upstream 3 September (release-dated 24 August, delivered to mainnet nodes before the public release): hardens low-level deserialization across six crates so non-canonical encodings and invariant-violating values are rejected, plus fixes for several panic and overflow paths.

`DynamicListLedger.js`: 8.1.2 LATEST, 8.1.1 demoted to SUPPORTED.

Detected by the `release-watch.yml` workflow the morning after publication.

Closes #1306

## Notes for review

- Support matrix: no change. The matrix has no ledger row, since as of Midnight.js 4.1.x the ledger is a transitive dependency of the node rather than something DApp developers pin. The proof server row stays at 8.1.0 because no 8.1.1 or 8.1.2 proof server image has been published to Docker Hub.
