### PR TITLE
fix(redirects): cover the Bun guide's legacy path and fix its next-steps link

### DIFF
--- a/docs/guides/install-bun-runtime-midnight.mdx
+++ b/docs/guides/install-bun-runtime-midnight.mdx
@@ -611,6 +611,6 @@ Now that you have Bun installed and configured, you can start building DApps on 
 
 - [DApp connector](/api-reference/dapp-connector)
 - [Deploy a contract](../guides/deploy-and-operate)
-- [Interact with a contract](../guides/interact-with-mn-app)
+- [Create your first Midnight contract](/getting-started/hello-world)
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -190,6 +190,11 @@
         "permanent": true
       },
       {
+        "source": "/guides/install-bun-runtime-midnight",
+        "destination": "/how-to/bun-runtime-midnight",
+        "permanent": true
+      },
+      {
         "source": "/guides/fix-package-repository-access-failures",
         "destination": "/how-to/fix-package-repository-access-failures",
         "permanent": true


### PR DESCRIPTION
## Summary
- Adds a `vercel.json` redirect from `/guides/install-bun-runtime-midnight` to `/how-to/bun-runtime-midnight`. The Bun guide lives at `docs/guides/install-bun-runtime-midnight.mdx` but sets a custom slug, so any page in `docs/guides` that links it relatively lands on a route that does not exist. This is the root-cause item from #1245; #1311 fixes the two links themselves.
- Repoints the Bun guide's own Next steps link from `../guides/interact-with-mn-app`, which the build reports as broken, to `/getting-started/hello-world`, the destination the site already redirects that old path to.

## Type of Change
- [x] Documentation update (content fixes, new pages)
- [x] Site improvement (UI/UX, infrastructure)
- [ ] New blog post
- [ ] Other (please specify)

## Related Links
- Documentation page(s) updated (if applicable): `docs/guides/install-bun-runtime-midnight.mdx`, `vercel.json`
- Other relevant resources (if any): #1245 (root-cause checkbox), #1311 (link fixes on the EffectStream guides)

## Issue Reference
Contributes to #1245

## Checklist
- [x] Followed the [Midnight Style Guide](https://docs.midnight.network/contributing/style-guide).
- [x] Previewed changes locally (`npm run start` or `yarn start`).
- [ ] Updated navigation metadata if needed (sidebar, menus).

## Notes
The redirect is a bare path placed next to the existing `/guides/bun-runtime-midnight` rule, ahead of the trailing `/(.*)` catch-all, so ordering is unaffected. `vercel.json` parses and has no duplicate sources.
